### PR TITLE
Improvements and many corrections

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -122,27 +122,35 @@ class helper_plugin_tag extends DokuWiki_Plugin {
         if (empty($tags) || ($tags[0] == '')) return '';
 
         foreach ($tags as $tag) {
-            $svtag = $tag;
-            $title = str_replace('_', ' ', noNS($tag));
-            resolve_pageid($this->namespace, $tag, $exists); // resolve shortcuts
-            if ($exists) {
-                $class = 'wikilink1';
-                $url   = wl($tag);
-                if ($conf['useheading']) {
-                    // important: set sendond param to false to prevent recursion!
-                    $heading = p_get_first_heading($tag, false);
-                    if ($heading) $title = $heading;
-                }
-            } else {
-                $class = 'wikilink1';
-                $url   = wl($tag, array('do'=>'showtag', 'tag'=>$svtag));
-            }
-            $links[] = '<a href="'.$url.'" class="'.$class.'" title="'.hsc($tag).
-                '" rel="tag">'.hsc($title).'</a>';
-            $this->references[$tag] = $exists;
+            $links[] = $this->tagLink($tag);
         }
 
         return implode(','.DOKU_LF.DOKU_TAB, $links);
+    }
+
+    /**
+     * Returns the link for one given tag
+     */
+    function tagLink($tag) {
+        $svtag = $tag;
+        $title = str_replace('_', ' ', noNS($tag));
+        resolve_pageid($this->namespace, $tag, $exists); // resolve shortcuts
+        if ($exists) {
+            $class = 'wikilink1';
+            $url   = wl($tag);
+            if ($conf['useheading']) {
+                // important: set sendond param to false to prevent recursion!
+                $heading = p_get_first_heading($tag, false);
+                if ($heading) $title = $heading;
+            }
+        } else {
+            $class = 'wikilink1';
+            $url   = wl($tag, array('do'=>'showtag', 'tag'=>$svtag));
+        }
+        $link = '<a href="'.$url.'" class="'.$class.'" title="'.hsc($tag).
+            '" rel="tag">'.hsc($title).'</a>';
+        $this->references[$tag] = $exists;
+        return $link;
     }
 
     /**
@@ -413,7 +421,10 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     function _updateTagIndex($id, $tags) {
         global $ID, $INFO;
 
+        // if nothing to do
         if (!is_array($tags) || empty($tags)) return false;
+        
+        // track changes
         $changed = false;
 
         // clean array first
@@ -422,31 +433,42 @@ class helper_plugin_tag extends DokuWiki_Plugin {
             $tags[$i] = utf8_strtolower($tags[$i]);
         }
 
-        // clear no longer used tags
-        if ($ID == $id) {
-            $oldtags = $INFO['meta']['subject'];
-            if (!is_array($oldtags)) $oldtags = explode(' ', $oldtags);
-            foreach ($oldtags as $oldtag) {
-                if (!$oldtag) continue;                 // skip empty tags
-                $oldtag = utf8_strtolower($oldtag);
-                if (in_array($oldtag, $tags)) continue; // tag is still there
-                if (!is_array($this->topic_idx[$oldtag]))
-                    $this->topic_idx[$oldtag] = array();
-                $this->topic_idx[$oldtag] = array_diff($this->topic_idx[$oldtag], array($id));
+        $knowntags = array(); // track known tags
+        // clear all no more used tags
+        foreach($this->topic_idx as $tag => $pages) {
+            if (!is_array($pages)) {
+                // clear unvalid type topic
+                unset($this->topic_idx[$tag]);
                 $changed = true;
-            }
-        }
-
-        // fill tag in
-        foreach ($tags as $tag) {
-            if (!$tag) continue; // skip empty tags
-            if (!is_array($this->topic_idx[$tag])) $this->topic_idx[$tag] = array();
-            if (!in_array($id, $this->topic_idx[$tag])) {
+            } elseif (in_array($id, $pages)) {
+                if(in_array($tag, $tags)) $knowntags[] = $tag; // nothing to do
+                else {
+                    // tag deleted from the page
+                    $this->topic_idx[$tag] = array_diff($this->topic_idx[$tag], array($id));
+                    $changed = true;
+                }
+            } elseif (in_array($tag, $tags)) {
+                // tag added to the page
                 $this->topic_idx[$tag][] = $id;
+                $knowntags[] = $tag;
+                $changed = true;
+            }
+            // clean empty topic
+            if (count($this->topic_idx[$tag]) == 0 || (!$tag)) {
+                unset($this->topic_idx[$tag]);
                 $changed = true;
             }
         }
 
+        // only new topics to add now
+        $newtopics = array_diff($tags, $knowntags);
+        if (count($newtopics) != 0 ) {
+            foreach($newtopics as $tag) {
+                if (!tag) continue; //skip empty tags
+                $this->topic_idx[$tag] = array($id);
+                $changed = true;
+            }
+        }
         // save tag index
         if ($changed) return $this->_saveIndex();
         else return true;
@@ -485,19 +507,24 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     }
 
     /**
-     * Generates the tag index
+     * Generates the tag index if file missing
      */
     function _generateTagIndex() {
         global $conf;
 
         require_once (DOKU_INC.'inc/search.php');
-
+        $topic_index = array();
         $pages = array();
         search($pages, $conf['datadir'], 'search_allpages', array());
         foreach ($pages as $page) {
-            $this->_generateTagData($page);
+            $tags = p_get_metadata($page['id'], 'subject');
+            if (!is_array($tags)) $tags = explode(' ', $tags);
+            foreach($tags as $tag) {
+                if (!$tag) continue; // drop empty tags
+                $topic_index[utf8_strtolower($tag)][] = $page['id'];
+            }
         }
-        return true;
+        return io_saveFile($this->idx_dir.'/topic.idx', serialize($topic_index));
     }
 
     /**

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * French language file
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ */
+
+// custom language strings for the plugin
+$lang['tags']  = 'Tags';
+$lang['topic'] = 'Topic';
+$lang['rebuildindex'] = 'Reconstruire l\'index des tags';
+$lang['toolbar_icon'] = 'Insérer des Tags';
+$lang['empty_output'] = 'Pas de résultat';
+
+$lang['missing_pagelistplugin'] = 'Le plugin Pagelist doit être installé pour la syntaxe topic.';
+
+$lang['menu'] = 'Gestion de l\'indexation des Tags';
+
+//Setup VIM: ex: et ts=2 :

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -8,11 +8,23 @@
  */
  
 // for the configuration manager
-$lang['namespace']      = 'espace de nommage par defaut pour les tags';
+$lang['namespace']      = 'Dossier par defaut pour les tags';
+$lang['pingtechnorati'] = 'Ping Technorati';
+$lang['toolbar_icon']   = 'Afficher l\'icone dans la barre d\'outils (purger data/cache/* et le cache du navigateur si il n\'apparait pas)';
 
-$lang['sortkey']            = 'trier par:';
+$lang['sortkey']            = 'trier par&nbsp;:';
 $lang['sortkey_o_cdate']    = 'date de creation';
+$lang['sortkey_o_mdate']    = 'date de modification';
 $lang['sortkey_o_pagename'] = 'nom de la page';
 $lang['sortkey_o_id']       = 'ID de la page';
+$lang['sortkey_o_title']    = 'titre';
+
+$lang['sortorder']              = 'ordre';
+$lang['sortorder_o_ascending']  = 'croissant';
+$lang['sortorder_o_descending'] = 'décroissant';
+
+$lang['pagelist_flags'] = 'Paramètres d\'affichage pour lister les pages (séparés par des virgules, pour la liste des paramètres voir la documentation du plugin pagelist)';
+
+$lang['list_tags_of_subns'] = 'Lister les tags présent aussi dans les sous-dossiers (syntaxe count)';
 
 //Setup VIM: ex: et ts=2 enc=utf-8 :

--- a/syntax/count.php
+++ b/syntax/count.php
@@ -95,11 +95,6 @@ class syntax_plugin_tag_count extends DokuWiki_Syntax_Plugin {
 
     function render($mode, &$renderer, $data) {
         if(!($my = plugin_load('helper', 'tag'))) return false;
-        $taglinks = $my->tagLinks(array_keys($data));
-        $taglinks = explode(',', $taglinks);
-        
-        // Prevent displaying a warning when result is empty
-        $tl = @array_combine(array_keys($data), $taglinks);
         
         // $data -> tag as key; value as count of tag occurence
         $class = "inline"; // valid: inline, ul, pagelist
@@ -122,11 +117,11 @@ class syntax_plugin_tag_count extends DokuWiki_Syntax_Plugin {
                 $renderer->doc .= DOKU_TAB.DOKU_TAB.'<td class="'.$class.'" colspan="2">'.$this->getLang('empty_output').'</td>'.DOKU_LF;
                 $renderer->doc .= DOKU_LF.DOKU_TAB.'</tr>'.DOKU_LF;
             } else {
-                foreach($data as $key => $tag) {
-                    if($tag <= 0) continue; // don't display tags with zero occurences
+                foreach($data as $tagname => $count) {
+                    if($count <= 0) continue; // don't display tags with zero occurences
                     $renderer->doc .= DOKU_TAB.'<tr>'.DOKU_LF.DOKU_TAB.DOKU_TAB;
-                    $renderer->doc .= DOKU_TAB.DOKU_TAB.'<td class="'.$class.'">'.$tl[$key].'</td>'.DOKU_LF;
-                    $renderer->doc .= DOKU_TAB.DOKU_TAB.'<td class="'.$class.'">'.$tag.'</td>'.DOKU_LF;
+                    $renderer->doc .= DOKU_TAB.DOKU_TAB.'<td class="'.$class.'">'.$my->tagLink($tagname).'</td>'.DOKU_LF;
+                    $renderer->doc .= DOKU_TAB.DOKU_TAB.'<td class="'.$class.'">'.$count.'</td>'.DOKU_LF;
                     $renderer->doc .= DOKU_LF.DOKU_TAB.'</tr>'.DOKU_LF;
                 }
             }

--- a/syntax/topic.php
+++ b/syntax/topic.php
@@ -87,12 +87,12 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
             return true;
 
         // for metadata renderer
-        } elseif ($mode == 'metadata') {
+/*        } elseif ($mode == 'metadata') {
             foreach ($pages as $page) {
                 $renderer->meta['relation']['references'][$page['id']] = true;
             }
 
-            return true;
+            return true;*/ // causes issues with backlinks
         }
         return false;
     }


### PR DESCRIPTION
Count syntax:
- simplification by using a taglink creation for each tags and not creating all taglinks at once causing an empty list when tags have a coma.
  Tag syntax:
- transfering the taglist to the render part where it is really used
- direct use of the taglist to update the metadata
- direct use of the resolve_pageid to update the relation reference metadata
  Topic syntax:
- commenting the relation reference metadata update, causing issue with backlinks of the pointed pages when tags are removed from them.
  Helper:
- Creating a taglink function
- rewrite of the _updateTagIndex function
- simplification of the _generateTagIndex using less ressources
