### PR TITLE
Implemented optional style from plugin's page

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -8,5 +8,6 @@ $conf['sortorder']          = 'ascending'; // ascending or descending
 $conf['pagelist_flags']     = 'list';      // formatting options for the page list plugin
 $conf['toolbar_icon']       = 0;	       // enables/disables the toolbar icon
 $conf['list_tags_of_subns'] = 0;           // list also tags in subnamespaces of a specified namespace (count syntax)
+$conf['tags_list_css']      = 'tags';     // wich CSS style to use for tag list?
 
 //Setup VIM: ex: et ts=2 :

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -14,5 +14,7 @@ $meta['sortorder']          = array('multichoice',
 $meta['pagelist_flags']     = array('string');
 $meta['toolbar_icon']       = array('onoff');
 $meta['list_tags_of_subns'] = array('onoff');
+$meta['tags_list_css']      = array('multichoice',
+                                    '_choices' => array('tags', 'tagstop'));
 
 //Setup VIM: ex: et ts=2 :

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -26,4 +26,9 @@ $lang['pagelist_flags'] = 'Formatting flags for the taglist (comma-separated, fo
 
 $lang['list_tags_of_subns'] = 'List also tags in subnamespaces of a specified namespace (count syntax)';
 
+$lang['tags_list_css']           = 'Choose style applied to pages\' tags list';
+$lang['tags_list_css_o_tags']    = 'default style';
+$lang['tags_list_css_o_tagstop'] = 'optimized for tags list at top of page';
+
+
 //Setup VIM: ex: et ts=2 :

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -21,3 +21,7 @@ $lang['sortorder_o_ascending'] = 'croissant';
 $lang['sortorder_o_descending'] = 'décroissant';
 $lang['pagelist_flags']        = 'Paramètres d\'affichage pour lister les pages (séparés par des virgules, pour la liste des paramètres voir la documentation du plugin pagelist)';
 $lang['list_tags_of_subns']    = 'Lister les tags présent aussi dans les sous-dossiers (syntaxe count)';
+
+$lang['tags_list_css']           = 'Style appliqué à la liste de tags des pages';
+$lang['tags_list_css_o_tags']    = 'style par défaut';
+$lang['tags_list_css_o_tagstop'] = 'optimisé pour les listes de tags en haut de page';

--- a/style.css
+++ b/style.css
@@ -6,6 +6,14 @@ div.dokuwiki div.tags {
   margin-bottom: 1.4em;
 }
 
+div.dokuwiki div.tagstop {
+  border-bottom: 2px dotted __border__;
+  font-size: 95%;
+  text-align: right;
+  margin-top: -1.3em;
+  margin-bottom: .4em;
+}
+
 div.dokuwiki div.tags span {
   background: transparent url(images/tag.gif) 0px 1px no-repeat;
   padding: 1px 0px 1px 16px;

--- a/syntax/tag.php
+++ b/syntax/tag.php
@@ -82,7 +82,7 @@ class syntax_plugin_tag_tag extends DokuWiki_Syntax_Plugin {
         if ($mode == 'xhtml') {
             $tags = $my->tagLinks($data);
             if (!$tags) return true;
-            $renderer->doc .= '<div class="tags"><span>'.DOKU_LF.
+            $renderer->doc .= '<div class="'.$this->getConf('tags_list_css').'"><span>'.DOKU_LF.
                 DOKU_TAB.$tags.DOKU_LF.
                 '</span></div>'.DOKU_LF;
             return true;


### PR DESCRIPTION
Hi

What I propose is a new option and code needed to give anyone an easy way to use a CSS
style optimized for tags list placed at top of page as proposed in plugin's official page FAQ (https://www.dokuwiki.org/plugin:tag#bad_appearance_when_displaying_tags_at_top_of_page).

Best regards
Simon