### PR TITLE
Adding a helper to enable tag list links styling

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -111,10 +111,13 @@ class helper_plugin_tag extends DokuWiki_Plugin {
         if (empty($tags) || ($tags[0] == '')) return '';
 
         $links = array();
+        // Load Tag Alerts helper if the plugin is not disabled
+        if (!plugin_isdisabled('tagalerts')) {
+            $this->tagalertsHelper = plugin_load('helper','tagalerts');
+        }
         foreach ($tags as $tag) {
             $links[] = $this->tagLink($tag);
         }
-
         return implode(','.DOKU_LF.DOKU_TAB, $links);
     }
 
@@ -153,6 +156,13 @@ class helper_plugin_tag extends DokuWiki_Plugin {
             $url   = wl($tag, array('do'=>'showtag', 'tag'=>$svtag));
         }
         if (!$title) $title = $tag_title;
+        // Use Tag Alerts helper if it has been loaded and is set to style tag links
+        if (($this->tagalertsHelper) and ($conf['plugin']['tagalerts']['inline'] == 1)) {
+            // get the CSS class
+            $class = $this->tagalertsHelper->extraClass($title, $class);
+            // get the tooltip
+            $tag = $this->tagalertsHelper->tooltip($title, $tag);
+        }
         $link = '<a href="'.$url.'" class="'.$class.'" title="'.hsc($tag).
             '" rel="tag">'.hsc($title).'</a>';
         return $link;


### PR DESCRIPTION
This is for a new plugin (ready for release) that can throw message alerts on
some tags or style the tag list links (wich looks much nicer), see this
page for an exemple and details: http://info.geekitude.fr/en/doku/plugin/tagalerts. The helper I'd like you to accept is needed to change tag list links style, not the messages.
![tagalerts_inline_en](https://cloud.githubusercontent.com/assets/8507657/8140326/ee640b2c-115a-11e5-9472-fd32c3e0f017.jpg)
![tagalerts_basic_messages_en](https://cloud.githubusercontent.com/assets/8507657/8140327/ee67291a-115a-11e5-80df-be96ba6234aa.jpg)
