### PR TITLE
Update tag.php

### DIFF
--- a/syntax/tag.php
+++ b/syntax/tag.php
@@ -54,6 +54,7 @@ class syntax_plugin_tag_tag extends DokuWiki_Syntax_Plugin {
     function handle($match, $state, $pos, &$handler) {
         $tags = trim(substr($match, 6, -2));     // strip markup & whitespace
         $tags = preg_replace(array('/[[:blank:]]+/', '/\s+/'), " ", $tags);    // replace linebreaks and multiple spaces with one space character
+        $tags = preg_replace('/:/', "", $tags);    // replace colon
 
         if (!$tags) return false;
         


### PR DESCRIPTION
Deletion of colons in tags

I have a problem with them on https://comicslate.org/gamer:awkward/0002 so I try to use htmlspecialchars() and htmlentities() but it ruins all html-specificated symbols, from spaces to colons. So I delete colons only
