### PR TITLE
Allow searching for tags in multiple namespaces 

### DIFF
--- a/syntax/topic.php
+++ b/syntax/topic.php
@@ -62,7 +62,6 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
 
         if (($ns == '*') || ($ns == ':')) $ns = '';
         elseif ($ns == '.') $ns = getNS($ID);
-        else $ns = cleanID($ns);
 
         return array($ns, trim($tag), $flags);
     }


### PR DESCRIPTION
This allows the topic component to search in multiple namespaces and even exclude sub namespaces. It uses a syntax similar to pagequery.
`{{topic>ns1 ns2?tag1}}` tag1 is in pages in namespaces ns1 or ns2
`{{topic>ns1 -ns1:subns?tag1}}` tag1 is pages in ns1 but not in ns1:subns
`{{topic>@ns1 ^ns1:subns?tag1}}` same as above with different syntax
