### PR TITLE
Add option for inline tags

### DIFF
--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -15,6 +15,6 @@ $meta['pagelist_flags']     = array('string');
 $meta['toolbar_icon']       = array('onoff');
 $meta['list_tags_of_subns'] = array('onoff');
 $meta['tags_list_css']      = array('multichoice',
-                                    '_choices' => array('tags', 'tagstop'));
+                                    '_choices' => array('tags', 'tagstop', 'tagsinline'));
 
 //Setup VIM: ex: et ts=2 :

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -29,6 +29,6 @@ $lang['list_tags_of_subns'] = 'List also tags in subnamespaces of a specified na
 $lang['tags_list_css']           = 'Choose style applied to pages\' tags list';
 $lang['tags_list_css_o_tags']    = 'default style';
 $lang['tags_list_css_o_tagstop'] = 'optimized for tags list at top of page';
-
+$lang['tags_list_css_o_tagsinline'] = 'display tags inline with content';
 
 //Setup VIM: ex: et ts=2 :

--- a/style.css
+++ b/style.css
@@ -22,7 +22,7 @@ div.dokuwiki div.tagsinline {
 }
 
 div.dokuwiki div.tags span,
-div.dokuwiki div.tagsinline span,
+div.dokuwiki span.tagsinline span,
 div.dokuwiki div.tagstop span {
   background: transparent url(images/tag.gif) 0px 2px no-repeat;
   padding: 1px 0px 1px 17px;

--- a/style.css
+++ b/style.css
@@ -16,7 +16,13 @@ div.dokuwiki div.tagstop {
   margin-bottom: .4em;
 }
 
+div.dokuwiki div.tagsinline { 
+  display: inline; 
+  font-size: 100%; 
+}
+
 div.dokuwiki div.tags span,
+div.dokuwiki div.tagsinline span,
 div.dokuwiki div.tagstop span {
   background: transparent url(images/tag.gif) 0px 2px no-repeat;
   padding: 1px 0px 1px 17px;
@@ -26,3 +32,4 @@ div.dokuwiki div.tagstop span {
 div.dokuwiki form.plugin__tag_search label.plus, div.dokuwiki form.plugin__tag_search label.minus {
   display: block;
 }
+

--- a/syntax/tag.php
+++ b/syntax/tag.php
@@ -33,7 +33,13 @@ class syntax_plugin_tag_tag extends DokuWiki_Syntax_Plugin {
     /**
      * @return string Paragraph type
      */
-    function getPType() { return 'block';}
+    function getPType() { 
+        if ($this->getConf('tags_list_css') == 'tagsinline') {
+            return 'normal';
+        } else {
+            return 'block';
+        }
+    }
 
     /**
      * @param string $mode Parser mode

--- a/syntax/tag.php
+++ b/syntax/tag.php
@@ -86,11 +86,15 @@ class syntax_plugin_tag_tag extends DokuWiki_Syntax_Plugin {
 
         // XHTML output
         if ($mode == 'xhtml') {
+            $container = 'div';
+            if ($this->getConf('tags_list_css') == 'tagsinline') {
+                $container = 'span';
+            }
             $tags = $my->tagLinks($data);
             if (!$tags) return true;
-            $renderer->doc .= '<div class="'.$this->getConf('tags_list_css').'"><span>'.DOKU_LF.
+            $renderer->doc .= '<'.$container.' class="'.$this->getConf('tags_list_css').'"><span>'.DOKU_LF.
                 DOKU_TAB.$tags.DOKU_LF.
-                '</span></div>'.DOKU_LF;
+                '</span></'.$container.'>'.DOKU_LF;
             return true;
 
         // for metadata renderer


### PR DESCRIPTION
This change adds an option to the display configuration setting for showing tags inline within paragraph content so that tags can be used as linked words within content, similar to how Zim handles @tags.  