### PR TITLE
fixes issue 145: Add sort key flag to topic

### DIFF
--- a/action.php
+++ b/action.php
@@ -4,11 +4,6 @@
  * @author     Esther Brunner <wikidesign@gmail.com>
  */
 
-// must be run within Dokuwiki
-if(!defined('DOKU_INC')) die();
-
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-
 /**
  * Action part of the tag plugin, handles tag display and index updates
  */
@@ -20,7 +15,6 @@ class action_plugin_tag extends DokuWiki_Action_Plugin {
      * @param Doku_Event_Handler $contr
      */
     function register(Doku_Event_Handler $contr) {
-        $contr->register_hook('PARSER_CACHE_USE', 'BEFORE', $this, '_purgecache', array());
         $contr->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, '_handle_act', array());
         $contr->register_hook('TPL_ACT_UNKNOWN', 'BEFORE', $this, '_handle_tpl_act', array());
         $contr->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, '_handle_keywords', array());
@@ -28,16 +22,6 @@ class action_plugin_tag extends DokuWiki_Action_Plugin {
         $contr->register_hook('INDEXER_VERSION_GET', 'BEFORE', $this, '_indexer_version', array());
         $contr->register_hook('INDEXER_PAGE_ADD', 'BEFORE', $this, '_indexer_index_tags', array());
     }
-	
-    /**
-    * when inserting custom sort keys we need to purge the cache
-    */
-    function _purgecache(Doku_Event $event, $param) {
-	$event->preventDefault();
-        $event->stopPropagation();
-        $event->result = false;
-    }
-	
 	
     /**
      * Add a version string to the index so it is rebuilt

--- a/action.php
+++ b/action.php
@@ -20,6 +20,7 @@ class action_plugin_tag extends DokuWiki_Action_Plugin {
      * @param Doku_Event_Handler $contr
      */
     function register(Doku_Event_Handler $contr) {
+        $contr->register_hook('PARSER_CACHE_USE', 'BEFORE', $this, '_purgecache', array());
         $contr->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, '_handle_act', array());
         $contr->register_hook('TPL_ACT_UNKNOWN', 'BEFORE', $this, '_handle_tpl_act', array());
         $contr->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, '_handle_keywords', array());
@@ -27,7 +28,17 @@ class action_plugin_tag extends DokuWiki_Action_Plugin {
         $contr->register_hook('INDEXER_VERSION_GET', 'BEFORE', $this, '_indexer_version', array());
         $contr->register_hook('INDEXER_PAGE_ADD', 'BEFORE', $this, '_indexer_index_tags', array());
     }
-
+	
+    /**
+    * when inserting custom sort keys we need to purge the cache
+    */
+    function _purgecache(Doku_Event $event, $param) {
+	$event->preventDefault();
+        $event->stopPropagation();
+        $event->result = false;
+    }
+	
+	
     /**
      * Add a version string to the index so it is rebuilt
      * whenever the stored data format changes.

--- a/helper.php
+++ b/helper.php
@@ -11,8 +11,8 @@
 class helper_plugin_tag extends DokuWiki_Plugin {
 
     var $namespace  = '';      // namespace tag links point to
-
     var $sort       = '';      // sort key
+    var $sortorder = '';       // sort order
     var $topic_idx  = array();
 
     /**
@@ -22,8 +22,11 @@ class helper_plugin_tag extends DokuWiki_Plugin {
         global $ID;
 
         $this->namespace = $this->getConf('namespace');
-        if (!$this->namespace) $this->namespace = getNS($ID);
+        if (!$this->namespace) {
+            $this->namespace = getNS($ID);
+        }
         $this->sort = $this->getConf('sortkey');
+        $this->sortorder = $this->getConf('sortorder');
     }
 
     /**
@@ -33,6 +36,13 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      */
     function getMethods() {
         $result = array();
+
+        $result[] = array(
+            'name'   => 'overrideSortFlags',
+            'desc'   => 'takes an array of sortflags and overrides predefined value',
+            'params' => array(
+                'name' => 'string')
+        );
         $result[] = array(
                 'name'   => 'th',
                 'desc'   => 'returns the header for the tags column for pagelist',
@@ -78,6 +88,15 @@ class helper_plugin_tag extends DokuWiki_Plugin {
                 'return' => array('tags' => 'array'),
                 );
         return $result;
+    }
+
+    function overrideSortFlags($newflags = array()) {
+        if(isset($newflags['sortkey'])) {
+            $this->sort = trim($newflags['sortkey']);
+        }
+        if(isset($newflags['sortorder'])) {
+            $this->sortorder = trim($newflags['sortorder']);
+        }
     }
 
     /**
@@ -197,17 +216,31 @@ class helper_plugin_tag extends DokuWiki_Plugin {
             $taglinks = $this->tagLinks($tags);
 
             // determine the sort key
-            if ($this->sort == 'id') $key = $page;
-            elseif ($this->sort == 'ns') {
-                $pos = strrpos($page, ':');
-                if ($pos === false) $key = "\0".$page;
-                else $key = substr_replace($page, "\0\0", $pos, 1);
-                $key = str_replace(':', "\0", $key);
-            } elseif ($this->sort == 'pagename') $key = noNS($page);
-            elseif ($this->sort == 'title') {
-                $key = utf8_strtolower($title);
-                if (empty($key)) $key = str_replace('_', ' ', noNS($page));
-            } else $key = $date;
+            switch($this->sort) {
+                case 'id':
+                    $key = $page;
+                    break;
+                case 'ns':
+                    $pos = strrpos($page, ':');
+                    if ($pos === false) {
+                        $key = "\0".$page;
+                    } else {
+                        $key = substr_replace($page, "\0\0", $pos, 1);
+                    }
+                    $key = str_replace(':', "\0", $key);
+                    break;
+                case 'pagename':
+                    $key = noNS($page);
+                    break;
+                case 'title':
+                    $key = utf8_strtolower($title);
+                    if (empty($key)) {
+                        $key = str_replace('_', ' ', noNS($page));
+                    }
+                    break;
+                default:
+                    $key = $date;
+            }
             // make sure that the key is unique
             $key = $this->_uniqueKey($key, $result);
 
@@ -227,7 +260,7 @@ class helper_plugin_tag extends DokuWiki_Plugin {
         }
 
         // finally sort by sort key
-        if ($this->getConf('sortorder') == 'ascending') ksort($result);
+        if ($this->sortorder == 'ascending') ksort($result);
         else krsort($result);
 
         return $result;

--- a/helper.php
+++ b/helper.php
@@ -5,12 +5,6 @@
  * @author     Esther Brunner <wikidesign@gmail.com>
  */
 
-// must be run within Dokuwiki
-if (!defined('DOKU_INC')) die();
-
-if (!defined('DOKU_LF')) define('DOKU_LF', "\n");
-if (!defined('DOKU_TAB')) define('DOKU_TAB', "\t");
-
 /**
  * Helper part of the tag plugin, allows to query and print tags
  */
@@ -343,7 +337,7 @@ class helper_plugin_tag extends DokuWiki_Plugin {
 
         $clean_tags = array();
         foreach ($tags as $i => $tag) {
-            if (($tag{0} == '+') || ($tag{0} == '-'))
+            if (($tag[0] == '+') || ($tag[0] == '-'))
                 $clean_tags[$i] = substr($tag, 1);
             else
                 $clean_tags[$i] = $tag;
@@ -358,9 +352,9 @@ class helper_plugin_tag extends DokuWiki_Plugin {
             $t = $clean_tags[$i];
             if (!is_array($pages[$t])) $pages[$t] = array();
 
-            if ($tag{0} == '+') {       // AND: add only if in both arrays
+            if ($tag[0] == '+') {       // AND: add only if in both arrays
                 $result = array_intersect($result, $pages[$t]);
-            } elseif ($tag{0} == '-') { // NOT: remove array from docs
+            } elseif ($tag[0] == '-') { // NOT: remove array from docs
                 $result = array_diff($result, $pages[$t]);
             } else {                   // OR: add array to docs
                 $result = array_unique(array_merge($result, $pages[$t]));
@@ -509,8 +503,8 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     function _checkPageTags($pagetags, $tags) {
         $result = false;
         foreach($tags as $tag) {
-            if ($tag{0} == "+" and !in_array(substr($tag, 1), $pagetags)) $result = false;
-            if ($tag{0} == "-" and in_array(substr($tag, 1), $pagetags)) $result = false;
+            if ($tag[0] == "+" and !in_array(substr($tag, 1), $pagetags)) $result = false;
+            if ($tag[0] == "-" and in_array(substr($tag, 1), $pagetags)) $result = false;
             if (in_array($tag, $pagetags)) $result = true;
         }
         return $result;

--- a/syntax/topic.php
+++ b/syntax/topic.php
@@ -79,7 +79,29 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
         list($ns, $tag, $flags) = $data;
 
         /* @var helper_plugin_tag $my */
-        if ($my = $this->loadHelper('tag')) $pages = $my->getTopic($ns, '', $tag);
+        if ($my = $this->loadHelper('tag')) {
+            // see if flags tell us to change settings for sorting
+            foreach($flags as $flag) {
+                $separator_pos = strpos($flag, '=');
+                if ($separator_pos === false) {
+                    continue; // no "=" found, skip to next flag
+                }
+
+                $conf_name = trim(strtolower(substr($flag, 0 , $separator_pos)));
+                $conf_val = trim(strtolower(substr($flag, $separator_pos+1)));
+
+                if(in_array($conf_name, array('sortkey', 'sortorder'))) {
+                    $my->conf[$conf_name] = $conf_val;
+                }
+
+                if('sortkey' == $conf_name) {
+                    $my->sort = $conf_val;
+                }
+            }
+            
+            $pages = $my->getTopic($ns, '', $tag);
+        }
+        
         if (!isset($pages) || !$pages) return true; // nothing to display
 
         if ($mode == 'xhtml') {

--- a/syntax/topic.php
+++ b/syntax/topic.php
@@ -6,11 +6,7 @@
  * @author   Esther Brunner <wikidesign@gmail.com>
  */
 
-// must be run within Dokuwiki
-if (!defined('DOKU_INC')) die();
-
-if (!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-
+/
 /**
  * Topic syntax, displays links to all wiki pages with a certain tag
  */
@@ -76,7 +72,6 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
      * @return bool If rendering was successful.
      */
     function render($mode, Doku_Renderer $renderer, $data) {
-	global $conf, $my;
         list($ns, $tag, $flags) = $data;
 
         /* @var helper_plugin_tag $my */
@@ -99,11 +94,9 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
             }
         }
 
-
         if ($my = $this->loadHelper('tag')) {
             $pages = $my->getTopic($ns, '', $tag);
         }
-
 
         if (!isset($pages) || !$pages) return true; // nothing to display
 
@@ -111,7 +104,7 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
             /* @var Doku_Renderer_xhtml $renderer */
 
             // prevent caching to ensure content is always fresh
-            $renderer->info['cache'] = false;
+            $renderer->nocache();
 
             /* @var helper_plugin_pagelist $pagelist */
             // let Pagelist Plugin do the work for us
@@ -144,14 +137,6 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
             }
             $renderer->doc .= $pagelist->finishList();      
             return true;
-
-        // for metadata renderer
-/*        } elseif ($mode == 'metadata') {
-            foreach ($pages as $page) {
-                $renderer->meta['relation']['references'][$page['id']] = true;
-            }
-
-            return true;*/ // causes issues with backlinks
         }
         return false;
     }

--- a/syntax/topic.php
+++ b/syntax/topic.php
@@ -6,7 +6,6 @@
  * @author   Esther Brunner <wikidesign@gmail.com>
  */
 
-/
 /**
  * Topic syntax, displays links to all wiki pages with a certain tag
  */

--- a/syntax/topic.php
+++ b/syntax/topic.php
@@ -73,7 +73,8 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
     function render($mode, Doku_Renderer $renderer, $data) {
         list($ns, $tag, $flags) = $data;
 
-        /* @var helper_plugin_tag $my */
+        /* extract sort flags into array */
+        $sortflags = array();
         foreach($flags as $flag) {
             $separator_pos = strpos($flag, '=');
             if ($separator_pos === false) {
@@ -84,16 +85,13 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
             $conf_val = trim(strtolower(substr($flag, $separator_pos+1)));
 
             if(in_array($conf_name, array('sortkey', 'sortorder'))) {
-                $conf['plugin']['tag'][$conf_name] = $conf_val;
-            }
-
-            if('sortkey' == $conf_name) {
-                $conf['plugin']['tag']['sort'] = $conf_val;
-                $my->sort = $conf_val;
+                $sortflags[$conf_name] = $conf_val;
             }
         }
 
+        /* @var helper_plugin_tag $my */
         if ($my = $this->loadHelper('tag')) {
+            $my->overrideSortFlags($sortflags);
             $pages = $my->getTopic($ns, '', $tag);
         }
 

--- a/syntax/topic.php
+++ b/syntax/topic.php
@@ -76,32 +76,35 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
      * @return bool If rendering was successful.
      */
     function render($mode, Doku_Renderer $renderer, $data) {
+	global $conf, $my;
         list($ns, $tag, $flags) = $data;
 
         /* @var helper_plugin_tag $my */
-        if ($my = $this->loadHelper('tag')) {
-            // see if flags tell us to change settings for sorting
-            foreach($flags as $flag) {
-                $separator_pos = strpos($flag, '=');
-                if ($separator_pos === false) {
-                    continue; // no "=" found, skip to next flag
-                }
-
-                $conf_name = trim(strtolower(substr($flag, 0 , $separator_pos)));
-                $conf_val = trim(strtolower(substr($flag, $separator_pos+1)));
-
-                if(in_array($conf_name, array('sortkey', 'sortorder'))) {
-                    $my->conf[$conf_name] = $conf_val;
-                }
-
-                if('sortkey' == $conf_name) {
-                    $my->sort = $conf_val;
-                }
+        foreach($flags as $flag) {
+            $separator_pos = strpos($flag, '=');
+            if ($separator_pos === false) {
+                continue; // no "=" found, skip to next flag
             }
-            
+
+            $conf_name = trim(strtolower(substr($flag, 0 , $separator_pos)));
+            $conf_val = trim(strtolower(substr($flag, $separator_pos+1)));
+
+            if(in_array($conf_name, array('sortkey', 'sortorder'))) {
+                $conf['plugin']['tag'][$conf_name] = $conf_val;
+            }
+
+            if('sortkey' == $conf_name) {
+                $conf['plugin']['tag']['sort'] = $conf_val;
+                $my->sort = $conf_val;
+            }
+        }
+
+
+        if ($my = $this->loadHelper('tag')) {
             $pages = $my->getTopic($ns, '', $tag);
         }
-        
+
+
         if (!isset($pages) || !$pages) return true; // nothing to display
 
         if ($mode == 'xhtml') {


### PR DESCRIPTION
Issue 145 addresses a problem a came across recently:
topics are sorted "sortkey" and "sortorder" according to settings in plugin config. 
Changing this "on demand" might be favourable sometimes. 

In my case, default sorting in config is set to "title", but in a namespace called "news" i would like to sort by date with newest items first.
This patch lets you add the flags "sortkey" and "sortorder", preserving all other functionality: 

`{{topic>.?news&table&header&comments&sortkey=mdate&sortorder=descending}}`