### PR TITLE
fix array access with curly braces in PHP 7.4

### DIFF
--- a/action.php
+++ b/action.php
@@ -23,7 +23,7 @@ class action_plugin_tag extends DokuWiki_Action_Plugin {
         $contr->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, '_handle_act', array());
         $contr->register_hook('TPL_ACT_UNKNOWN', 'BEFORE', $this, '_handle_tpl_act', array());
         $contr->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, '_handle_keywords', array());
-        if($this->getConf('toolbar_icon'))	$contr->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insert_toolbar_button', array ());
+        if($this->getConf('toolbar_icon')) $contr->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insert_toolbar_button', array ());
         $contr->register_hook('INDEXER_VERSION_GET', 'BEFORE', $this, '_indexer_version', array());
         $contr->register_hook('INDEXER_PAGE_ADD', 'BEFORE', $this, '_indexer_index_tags', array());
     }
@@ -100,44 +100,44 @@ class action_plugin_tag extends DokuWiki_Action_Plugin {
 
             print '<h1>TAG: ' . hsc(str_replace('_', ' ', $_REQUEST['tag'])) . '</h1>' . DOKU_LF;
             print '<div class="level1">' . DOKU_LF;
-            print $pagelist->finishList();      
+            print $pagelist->finishList();
             print '</div>' . DOKU_LF;
 
         } else {
             print '<div class="level1"><p>' . $lang['nothingfound'] . '</p></div>';
         }
     }
-    
-	/**
-	 * Inserts the tag toolbar button
-	 */
-	function insert_toolbar_button(Doku_Event $event, $param) {
-	    $event->data[] = array (
-	        'type' => 'format',
-	        'title' => $this->getLang('toolbar_icon'),
-	        'icon' => '../../plugins/tag/images/tag-toolbar.png',
-	        'open' => '{{tag>',
-	    	'close' => '}}'
-	    );
-	}
-	
-	/**
-	 * Prevent displaying underscores instead of blanks inside the page keywords
-	 */
-	function _handle_keywords(Doku_Event $event) {
-	    global $ID;
 
-	    // Fetch tags for the page; stop proceeding when no tags specified
-	    $tags = p_get_metadata($ID, 'subject', METADATA_DONT_RENDER);
-	    if(is_null($tags)) true;
+    /**
+     * Inserts the tag toolbar button
+     */
+    function insert_toolbar_button(Doku_Event $event, $param) {
+        $event->data[] = array(
+            'type' => 'format',
+            'title' => $this->getLang('toolbar_icon'),
+            'icon' => '../../plugins/tag/images/tag-toolbar.png',
+            'open' => '{{tag>',
+            'close' => '}}'
+        );
+    }
 
-	    // Replace underscores with blanks
-	    foreach($event->data['meta'] as &$meta) {
-	        if($meta['name'] == 'keywords') {
-	            $meta['content'] = str_replace('_', ' ', $meta['content']);
-	        }
-	    }	    
-	}
+    /**
+     * Prevent displaying underscores instead of blanks inside the page keywords
+     */
+    function _handle_keywords(Doku_Event $event) {
+        global $ID;
+
+        // Fetch tags for the page; stop proceeding when no tags specified
+        $tags = p_get_metadata($ID, 'subject', METADATA_DONT_RENDER);
+        if(is_null($tags)) true;
+
+        // Replace underscores with blanks
+        foreach($event->data['meta'] as &$meta) {
+            if($meta['name'] == 'keywords') {
+                $meta['content'] = str_replace('_', ' ', $meta['content']);
+            }
+        }
+    }
 }
 
 // vim:ts=4:sw=4:et:

--- a/helper.php
+++ b/helper.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Esther Brunner <wikidesign@gmail.com>
@@ -343,7 +342,7 @@ class helper_plugin_tag extends DokuWiki_Plugin {
 
         $clean_tags = array();
         foreach ($tags as $i => $tag) {
-            if (($tag{0} == '+') || ($tag{0} == '-'))
+            if (($tag[0] == '+') || ($tag[0] == '-'))
                 $clean_tags[$i] = substr($tag, 1);
             else
                 $clean_tags[$i] = $tag;
@@ -358,9 +357,9 @@ class helper_plugin_tag extends DokuWiki_Plugin {
             $t = $clean_tags[$i];
             if (!is_array($pages[$t])) $pages[$t] = array();
 
-            if ($tag{0} == '+') {       // AND: add only if in both arrays
+            if ($tag[0] == '+') {       // AND: add only if in both arrays
                 $result = array_intersect($result, $pages[$t]);
-            } elseif ($tag{0} == '-') { // NOT: remove array from docs
+            } elseif ($tag[0] == '-') { // NOT: remove array from docs
                 $result = array_diff($result, $pages[$t]);
             } else {                   // OR: add array to docs
                 $result = array_unique(array_merge($result, $pages[$t]));
@@ -509,8 +508,8 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     function _checkPageTags($pagetags, $tags) {
         $result = false;
         foreach($tags as $tag) {
-            if ($tag{0} == "+" and !in_array(substr($tag, 1), $pagetags)) $result = false;
-            if ($tag{0} == "-" and in_array(substr($tag, 1), $pagetags)) $result = false;
+            if ($tag[0] == "+" and !in_array(substr($tag, 1), $pagetags)) $result = false;
+            if ($tag[0] == "-" and in_array(substr($tag, 1), $pagetags)) $result = false;
             if (in_array($tag, $pagetags)) $result = true;
         }
         return $result;

--- a/syntax/searchtags.php
+++ b/syntax/searchtags.php
@@ -237,7 +237,7 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
             $negative_tags = '';
             foreach ($tags as $tag) {
                 $tag = (string)$tag;
-                if ($tag{0} == '-') {
+                if ($tag[0] == '-') {
                     $negative_tags .= $tag.' ';
                 } else {
                     if ($positive_tags === '') {


### PR DESCRIPTION
Array and string offset access syntax with curly braces is deprecated in php 7.4
please see https://www.php.net/manual/en/migration74.deprecated.php
