### PR TITLE
Cleanup

### DIFF
--- a/_test/topic_and_tagrefine.test.php
+++ b/_test/topic_and_tagrefine.test.php
@@ -6,11 +6,11 @@ if (!defined('DOKU_INC')) die();
  * Tests the tagRefine function of the tag plugin
  */
 class plugin_tag_topic_and_tagrefine_test extends DokuWikiTest {
-    private $all_pages = array(
-        'tagged_page' => array('id' => 'tagged_page'),
-        'negative_page' => array('id' => 'negative_page'),
-        'third_page' => array('id' => 'third_page')
-    );
+    private $all_pages = [
+        'tagged_page' => ['id' => 'tagged_page'],
+        'negative_page' => ['id' => 'negative_page'],
+        'third_page' => ['id' => 'third_page']
+    ];
     public function setUp() : void {
         $this->pluginsEnabled[] = 'tag';
         parent::setUp();
@@ -35,35 +35,35 @@ class plugin_tag_topic_and_tagrefine_test extends DokuWikiTest {
     }
 
     public function testEmptyTag() {
-        $this->assertTopicRefine(array('tagged_page', 'negative_page', 'third_page'), '');
+        $this->assertTopicRefine(['tagged_page', 'negative_page', 'third_page'], '');
     }
 
     public function testOnlyNegative() {
-        $this->assertTopicRefine(array('tagged_page', 'third_page'), '-negative_tag');
+        $this->assertTopicRefine(['tagged_page', 'third_page'], '-negative_tag');
     }
 
     public function testMixed() {
-        $this->assertTopicRefine(array('tagged_page'), 'mytag -negative_tag');
+        $this->assertTopicRefine(['tagged_page'], 'mytag -negative_tag');
 
     }
 
     public function testAnd() {
-        $this->assertTopicRefine(array('tagged_page'), '+mytag +test2tag');
+        $this->assertTopicRefine(['tagged_page'], '+mytag +test2tag');
     }
 
     public function testAndOr() {
-        $this->assertTopicRefine(array('tagged_page',  'third_page'), '+test2tag third_tag');
+        $this->assertTopicRefine(['tagged_page',  'third_page'], '+test2tag third_tag');
     }
 
     public function testOrAnd() {
-        $this->assertTopicRefine(array('tagged_page'), 'mytag +test2tag');
+        $this->assertTopicRefine(['tagged_page'], 'mytag +test2tag');
     }
 
     public function testRefineDoesntAdd() {
         /** @var helper_plugin_tag $helper */
         $helper = plugin_load('helper', 'tag');
-        $pages = $helper->tagRefine(array(), 'mytag');
-        $this->hasPages(array(), $pages, 'Refine with empty input array and "mytag" query: ');
+        $pages = $helper->tagRefine([], 'mytag');
+        $this->hasPages([], $pages, 'Refine with empty input array and "mytag" query: ');
     }
 
     /**

--- a/action.php
+++ b/action.php
@@ -45,7 +45,7 @@ class action_plugin_tag extends DokuWiki_Action_Plugin {
             if (!is_array($tags)) {
                 $event->data['metadata']['subject'] = array();
             } else {
-                $event->data['metadata']['subject'] = $helper->_cleanTagList($tags);
+                $event->data['metadata']['subject'] = $helper->cleanTagList($tags);
             }
         }
     }
@@ -137,5 +137,3 @@ class action_plugin_tag extends DokuWiki_Action_Plugin {
         }
     }
 }
-
-// vim:ts=4:sw=4:et:

--- a/action.php
+++ b/action.php
@@ -68,7 +68,7 @@ class action_plugin_tag extends DokuWiki_Action_Plugin {
      * @return bool
      */
     function _handle_tpl_act(Doku_Event $event, $param) {
-        global $lang;
+        global $lang, $INPUT;
 
         if($event->data != 'showtag') return;
         $event->preventDefault();
@@ -76,8 +76,8 @@ class action_plugin_tag extends DokuWiki_Action_Plugin {
         $tagns = $this->getConf('namespace');
         $flags = explode(',', str_replace(" ", "", $this->getConf('pagelist_flags')));
 
-        $tag   = trim(str_replace($this->getConf('namespace').':', '', $_REQUEST['tag']));
-        $ns    = trim($_REQUEST['ns']);
+        $tag   = trim(str_replace($tagns.':', '', $INPUT->str('tag')));
+        $ns    = trim($INPUT->str('ns'));
 
         /* @var helper_plugin_tag $helper */
         if ($helper = $this->loadHelper('tag')) $pages = $helper->getTopic($ns, '', $tag);
@@ -96,7 +96,7 @@ class action_plugin_tag extends DokuWiki_Action_Plugin {
                 $pagelist->addPage($page);
             }
 
-            print '<h1>TAG: ' . hsc(str_replace('_', ' ', $_REQUEST['tag'])) . '</h1>' . DOKU_LF;
+            print '<h1>TAG: ' . hsc(str_replace('_', ' ', $INPUT->str('tag'))) . '</h1>' . DOKU_LF;
             print '<div class="level1">' . DOKU_LF;
             print $pagelist->finishList();
             print '</div>' . DOKU_LF;

--- a/action.php
+++ b/action.php
@@ -12,17 +12,19 @@ class action_plugin_tag extends DokuWiki_Action_Plugin {
     /**
      * register the eventhandlers
      *
-     * @param Doku_Event_Handler $contr
+     * @param Doku_Event_Handler $controller
      */
-    function register(Doku_Event_Handler $contr) {
-        $contr->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, '_handle_act', array());
-        $contr->register_hook('TPL_ACT_UNKNOWN', 'BEFORE', $this, '_handle_tpl_act', array());
-        $contr->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, '_handle_keywords', array());
-        if($this->getConf('toolbar_icon')) $contr->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insert_toolbar_button', array ());
-        $contr->register_hook('INDEXER_VERSION_GET', 'BEFORE', $this, '_indexer_version', array());
-        $contr->register_hook('INDEXER_PAGE_ADD', 'BEFORE', $this, '_indexer_index_tags', array());
+    function register(Doku_Event_Handler $controller) {
+        $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, '_handle_act', array());
+        $controller->register_hook('TPL_ACT_UNKNOWN', 'BEFORE', $this, '_handle_tpl_act', array());
+        $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, '_handle_keywords', array());
+        if($this->getConf('toolbar_icon')) {
+            $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insert_toolbar_button', array ());
+        }
+        $controller->register_hook('INDEXER_VERSION_GET', 'BEFORE', $this, '_indexer_version', array());
+        $controller->register_hook('INDEXER_PAGE_ADD', 'BEFORE', $this, '_indexer_index_tags', array());
     }
-	
+
     /**
      * Add a version string to the index so it is rebuilt
      * whenever the stored data format changes.

--- a/helper.php
+++ b/helper.php
@@ -187,7 +187,8 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      * @author  Esther Brunner <wikidesign@gmail.com>
      */
     function getTopic($ns = '', $num = NULL, $tag = '') {
-        if (!$tag) $tag = $_REQUEST['tag'];
+        global $INPUT;
+        if (!$tag) $tag = $INPUT->str('tag');
         $tag = $this->_parseTagList($tag, true);
         $result = array();
 
@@ -208,10 +209,10 @@ class helper_plugin_tag extends DokuWiki_Plugin {
             $perm = auth_quickaclcheck($page);
 
             // skip drafts unless for users with create privilege
-            $draft = ($meta['type'] == 'draft');
+            $draft = isset($meta['type']) && $meta['type'] == 'draft';
             if ($draft && ($perm < AUTH_CREATE)) continue;
 
-            $title = $meta['title'];
+            $title = $meta['title'] ?? '';
             $date  = ($this->sort == 'mdate' ? $meta['date']['modified'] : $meta['date']['created'] );
             $taglinks = $this->tagLinks($tags);
 
@@ -445,9 +446,9 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      */
     function _applyMacro($id) {
         /** @var DokuWiki_Auth_Plugin $auth */
-        global $INFO, $auth;
+        global $INFO, $auth, $INPUT;
 
-        $user     = $_SERVER['REMOTE_USER'];
+        $user     = $INPUT->server->str('REMOTE_USER');
         $group    = '';
         // .htaccess auth doesn't provide the auth object
         if($auth) {
@@ -457,7 +458,7 @@ class helper_plugin_tag extends DokuWiki_Plugin {
 
         $replace = array(
                 '@USER@'  => cleanID($user),
-                '@NAME@'  => cleanID($INFO['userinfo']['name']),
+                '@NAME@'  => cleanID($INFO['userinfo']['name'] ?? ''),
                 '@GROUP@' => cleanID($group),
                 '@YEAR@'  => date('Y'),
                 '@MONTH@' => date('m'),

--- a/helper.php
+++ b/helper.php
@@ -48,62 +48,74 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      *
      * @return array Method description
      */
-        $result = array();
     public function getMethods() {
+        $result = [];
 
-        $result[] = array(
+        $result[] = [
             'name'   => 'overrideSortFlags',
             'desc'   => 'takes an array of sortflags and overrides predefined value',
-            'params' => array(
-                'name' => 'string')
-        );
-        $result[] = array(
+            'params' => [
+                'name' => 'string'
+            ]
+        ];
+        $result[] = [
                 'name'   => 'th',
                 'desc'   => 'returns the header for the tags column for pagelist',
-                'return' => array('header' => 'string'),
-                );
-        $result[] = array(
+                'return' => ['header' => 'string'],
+        ];
+        $result[] = [
                 'name'   => 'td',
                 'desc'   => 'returns the tag links of a given page',
-                'params' => array('id' => 'string'),
-                'return' => array('links' => 'string'),
-                );
-        $result[] = array(
+                'params' => ['id' => 'string'],
+                'return' => ['links' => 'string'],
+        ];
+        $result[] = [
                 'name'   => 'tagLinks',
                 'desc'   => 'generates tag links for given words',
-                'params' => array('tags' => 'array'),
-                'return' => array('links' => 'string'),
-                );
-        $result[] = array(
+                'params' => ['tags' => 'array'],
+                'return' => ['links' => 'string'],
+        ];
+        $result[] = [
                 'name'   => 'getTopic',
                 'desc'   => 'returns a list of pages tagged with the given keyword',
-                'params' => array(
+                'params' => [
                     'namespace (optional)' => 'string',
                     'number (not used)' => 'integer',
-                    'tag (required)' => 'string'),
-                'return' => array('pages' => 'array'),
-                );
-        $result[] = array(
+                    'tag (required)' => 'string'
+                ],
+                'return' => ['pages' => 'array'],
+        ];
+        $result[] = [
                 'name'   => 'tagRefine',
                 'desc'   => 'refines an array of pages with tags',
-                'params' => array(
+                'params' => [
                     'pages to refine' => 'array',
-                    'refinement tags' => 'string'),
-                'return' => array('pages' => 'array'),
-                );
-        $result[] = array(
+                    'refinement tags' => 'string'
+                ],
+                'return' => ['pages' => 'array'],
+        ];
+        $result[] = [
                 'name'   => 'tagOccurrences',
                 'desc'   => 'returns a list of tags with their number of occurrences',
-                'params' => array(
+                'params' => [
                     'list of tags to get the occurrences for' => 'array',
                     'namespaces to which the search shall be restricted' => 'array',
                     'if all tags shall be returned (then the first parameter is ignored)' => 'boolean',
-                    'if the namespaces shall be searched recursively' => 'boolean'),
-                'return' => array('tags' => 'array'),
-                );
+                    'if the namespaces shall be searched recursively' => 'boolean'
+                ],
+                'return' => ['tags' => 'array'],
+        ];
         return $result;
     }
 
+    /**
+     * Takes an array of sortflags and overrides predefined value
+     *
+     * @param array $newflags recognizes:
+     *      'sortkey' => string,
+     *      'sortorder' => string
+     * @return void
+     */
     public function overrideSortFlags($newflags = []) {
         if(isset($newflags['sortkey'])) {
             $this->sort = trim($newflags['sortkey']);
@@ -122,6 +134,9 @@ class helper_plugin_tag extends DokuWiki_Plugin {
 
     /**
      * Returns the cell data for the Pagelist Plugin
+     *
+     * @param string $id page id
+     * @return string html content for cell of table
      */
     public function td($id) {
         $subject = $this->getTagsFromPageMetadata($id);
@@ -142,8 +157,10 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      * @param array $tags an array of tags
      * @return string HTML link tags
      */
-        if (empty($tags) || ($tags[0] == '')) return '';
     public function tagLinks($tags) {
+        if (empty($tags) || ($tags[0] == '')) {
+            return '';
+        }
 
         $links = array();
         foreach ($tags as $tag) {
@@ -163,15 +180,17 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     public function tagLink($tag, $title = '', $dynamic = false) {
         global $conf;
         $svtag = $tag;
-        $tag_title = str_replace('_', ' ', noNS($tag));
+        $tagTitle = str_replace('_', ' ', noNS($tag));
         resolve_pageid($this->namespace, $tag, $exists); // resolve shortcuts
         if ($exists) {
             $class = 'wikilink1';
             $url   = wl($tag);
             if ($conf['useheading']) {
-                // important: set sendond param to false to prevent recursion!
+                // important: set render param to false to prevent recursion!
                 $heading = p_get_first_heading($tag, false);
-                if ($heading) $tag_title = $heading;
+                if ($heading) {
+                    $tagTitle = $heading;
+                }
             }
         } else {
             if ($dynamic) {
@@ -184,17 +203,21 @@ class helper_plugin_tag extends DokuWiki_Plugin {
             } else {
                 $class = 'wikilink1';
             }
-            $url   = wl($tag, array('do'=>'showtag', 'tag'=>$svtag));
+            $url   = wl($tag, ['do'=>'showtag', 'tag'=>$svtag]);
         }
-        if (!$title) $title = $tag_title;
-        $link = array(
+        if (!$title) {
+            $title = $tagTitle;
+        }
+        $link = [
             'href' => $url,
             'class' => $class,
             'tooltip' => hsc($tag),
             'title' => hsc($title)
-        );
+        ];
         Event::createAndTrigger('PLUGIN_TAG_LINK', $link);
-        return '<a href="'.$link['href'].'" class="'.$link['class'].'" title="'.$link['tooltip'].'" rel="tag">'.$link['title'].'</a>';
+        return '<a href="'.$link['href'].'" class="'.$link['class'].'" title="'.$link['tooltip'].'" rel="tag">'
+                .$link['title']
+                .'</a>';
     }
 
     /**
@@ -335,10 +358,15 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     */
     public function tagOccurrences($tags, $namespaces = null, $allTags = false, $isRecursive = null) {
         // map with trim here in order to remove newlines from tags
-        if($allTags) $tags = array_map('trim', idx_getIndex('subject', '_w'));
-        if(!$namespaces || $namespaces[0] == '' || !is_array($namespaces)) $namespaces = NULL; // $namespaces not specified
+        if($allTags) {
+            $tags = array_map('trim', idx_getIndex('subject', '_w'));
+        }
         $tags = $this->cleanTagList($tags);
         $tagOccurrences = []; //occurrences
+        // $namespaces not specified
+        if(!$namespaces || $namespaces[0] == '' || !is_array($namespaces)) {
+            $namespaces = null;
+        }
 
         $indexer = idx_get_indexer();
         $indexedPagesWithTags = $indexer->lookupKey('subject', $tags, array($this, 'tagCompare'));
@@ -391,14 +419,16 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     }
 
     /**
-     * Get the subject metadata cleaning the result
+     * Get tags from the 'subject' metadata field
      *
      * @param string $id the page id
      * @return array
      */
     protected function getTagsFromPageMetadata($id){
         $tags = p_get_metadata($id, 'subject');
-        if (!is_array($tags)) $tags = explode(' ', $tags);
+        if (!is_array($tags)) {
+            $tags = explode(' ', $tags);
+        }
         return array_unique($tags);
     }
 
@@ -456,7 +486,7 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      */
     public function parseTagList($tags, $clean = false) {
 
-        // support for "quoted phrase tags"
+        // support for "quoted phrase tags", replaces spaces by underscores
         if (preg_match_all('#".*?"#', $tags, $matches)) {
             foreach ($matches[0] as $match) {
                 $replace = str_replace(' ', '_', substr($match, 1, -1));
@@ -475,13 +505,19 @@ class helper_plugin_tag extends DokuWiki_Plugin {
 
     /**
      * Clean a list (array) of tags using _cleanTag
+     *
+     * @param string[] $tags
+     * @return string[]
      */
     public function cleanTagList($tags) {
         return array_unique(array_map([$this, 'cleanTag'], $tags));
     }
 
     /**
-     * Cleans a tag using cleanID while preserving a possible prefix of + or -
+     * callback: Cleans a tag using cleanID while preserving a possible prefix of + or -, and replace placeholders
+     *
+     * @param string $tag
+     * @return string
      */
     protected function cleanTag($tag) {
         $prefix = substr($tag, 0, 1);
@@ -494,7 +530,10 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     }
 
     /**
-     * Makes user or date dependent topic lists possible
+     * Makes user or date dependent topic lists possible by replacing placeholders in tags
+     *
+     * @param string $tag
+     * @return string
      */
     protected function replacePlaceholders($tag) {
         global $INFO, $INPUT;
@@ -508,28 +547,34 @@ class helper_plugin_tag extends DokuWiki_Plugin {
             $group = '';
         }
 
-        $replace = array(
+        $replace = [
                 '@USER@'  => cleanID($user),
                 '@NAME@'  => cleanID($INFO['userinfo']['name'] ?? ''),
                 '@GROUP@' => cleanID($group), //FIXME or delete, is unreliable because just first entry of group array is used, regardless the order of groups..
                 '@YEAR@'  => date('Y'),
                 '@MONTH@' => date('m'),
                 '@DAY@'   => date('d'),
-                );
-        return str_replace(array_keys($replace), array_values($replace), $id);
+        ];
+        return str_replace(array_keys($replace), array_values($replace), $tag);
     }
 
     /**
      * Non-recursive function to check whether an array key is unique
      *
-     * @author    Esther Brunner <wikidesign@gmail.com>
+     * @param int|string $key
+     * @param array $result
+     * @return float|int|string
+     *
      * @author    Ilya S. Lebedev <ilya@lebedev.net>
+     * @author    Esther Brunner <wikidesign@gmail.com>
      */
     protected function uniqueKey($key, $result) {
 
         // increase numeric keys by one
         if (is_numeric($key)) {
-            while (array_key_exists($key, $result)) $key++;
+            while (array_key_exists($key, $result)) {
+                $key++;
+            }
             return $key;
 
             // append a number to literal keys
@@ -545,7 +590,11 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     }
 
     /**
-     * Opposite of _notVisible
+     * Opposite of isNotVisible()
+     *
+     * @param string $id the page id
+     * @param string $ns
+     * @return bool if the page is shown
      */
     public function isVisible($id, $ns='') {
         return !$this->isNotVisible($id, $ns);
@@ -558,24 +607,37 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      * @param string $ns the namespace authorized
      * @return bool if the page is hidden
      */
-        if (isHiddenPage($id)) return true; // discard hidden pages
     public function isNotVisible($id, $ns="") {
+        // discard hidden pages
+        if (isHiddenPage($id)) {
+            return true;
+        }
         // discard if user can't read
-        if (auth_quickaclcheck($id) < AUTH_READ) return true;
+        if (auth_quickaclcheck($id) < AUTH_READ) {
+            return true;
+        }
 
         // filter by namespace, root namespace is identified with a dot
         if($ns == '.') {
             // root namespace is specified, discard all pages who lay outside the root namespace
-            if(getNS($id) != false) return true;
+            if(getNS($id) !== false) {
+                return true;
+            }
         } else {
-            // ("!==0" namespace found at position 0)
-            if ($ns && (strpos(':'.getNS($id).':', ':'.$ns.':') !== 0)) return true;
+            // hide if ns is not matching the page id (match gives strpos===0)
+            if ($ns && strpos(':'.getNS($id).':', ':'.$ns.':') !== 0) {
+                return true;
+            }
         }
         return !page_exists($id, '', false);
     }
 
     /**
-     * Helper function for the indexer in order to avoid interpreting wildcards
+     * callback Helper function for the indexer in order to avoid interpreting wildcards
+     *
+     * @param string $tag1 tag being searched
+     * @param string $tag2 tag from index
+     * @return bool is equal?
      */
     public function tagCompare($tag1, $tag2) {
         return $tag1 === $tag2;

--- a/helper.php
+++ b/helper.php
@@ -182,7 +182,15 @@ class helper_plugin_tag extends DokuWiki_Plugin {
         global $conf;
         $svtag = $tag;
         $tagTitle = str_replace('_', ' ', noNS($tag));
-        resolve_pageid($this->namespace, $tag, $exists); // resolve shortcuts
+        // Igor and later
+        if (class_exists('dokuwiki\File\PageResolver')) {
+            $resolver = new dokuwiki\File\PageResolver($this->namespace . ':something');
+            $tag = $resolver->resolveId($tag);
+            $exists = page_exists($tag);
+        } else {
+            // Compatibility with older releases
+            resolve_pageid($this->namespace, $tag, $exists);
+        }
         if ($exists) {
             $class = 'wikilink1';
             $url   = wl($tag);

--- a/helper.php
+++ b/helper.php
@@ -5,6 +5,7 @@
  */
 
 use dokuwiki\Extension\Event;
+use dokuwiki\Utf8\PhpString;
 
 /**
  * Helper part of the tag plugin, allows to query and print tags
@@ -283,7 +284,7 @@ class helper_plugin_tag extends DokuWiki_Plugin {
                     $sortkey = noNS($page);
                     break;
                 case 'title':
-                    $sortkey = utf8_strtolower($title);
+                    $sortkey = PhpString::strtolower($title);
                     if (empty($sortkey)) {
                         $sortkey = str_replace('_', ' ', noNS($page));
                     }
@@ -372,8 +373,9 @@ class helper_plugin_tag extends DokuWiki_Plugin {
         $indexedPagesWithTags = $indexer->lookupKey('subject', $tags, array($this, 'tagCompare'));
 
         $isRootAllowed = !($namespaces === null) && in_array('.', $namespaces);
-        if ($isRecursive === null)
+        if ($isRecursive === null) {
             $isRecursive = $this->getConf('list_tags_of_subns');
+        }
 
         foreach ($tags as $tag) {
             if (!isset($indexedPagesWithTags[$tag])) continue;

--- a/helper.php
+++ b/helper.php
@@ -496,22 +496,22 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     /**
      * Makes user or date dependent topic lists possible
      */
-        /** @var DokuWiki_Auth_Plugin $auth */
-        global $INFO, $auth, $INPUT;
     protected function replacePlaceholders($tag) {
+        global $INFO, $INPUT;
 
-        $user     = $INPUT->server->str('REMOTE_USER');
-        $group    = '';
-        // .htaccess auth doesn't provide the auth object
-        if($auth) {
-            $userdata = $auth->getUserData($user);
-            $group    = $userdata['grps'][0];
+        $user = $INPUT->server->str('REMOTE_USER');
+
+        //only available for logged-in users
+        if(isset($INFO['userinfo']['grps'])) {
+            $group = $INFO['userinfo']['grps'][0];
+        }   else {
+            $group = '';
         }
 
         $replace = array(
                 '@USER@'  => cleanID($user),
                 '@NAME@'  => cleanID($INFO['userinfo']['name'] ?? ''),
-                '@GROUP@' => cleanID($group),
+                '@GROUP@' => cleanID($group), //FIXME or delete, is unreliable because just first entry of group array is used, regardless the order of groups..
                 '@YEAR@'  => date('Y'),
                 '@MONTH@' => date('m'),
                 '@DAY@'   => date('d'),

--- a/helper.php
+++ b/helper.php
@@ -11,15 +11,28 @@ use dokuwiki\Extension\Event;
  */
 class helper_plugin_tag extends DokuWiki_Plugin {
 
-    var $namespace  = '';      // namespace tag links point to
-    var $sort       = '';      // sort key
-    var $sortorder = '';       // sort order
-    var $topic_idx  = array();
+    /**
+     * @var string namespace tag links point to
+     */
+    protected $namespace;
+    /**
+     * @var string sort key: 'cdate', 'mdate', 'pagename', 'id', 'ns', 'title'
+     */
+    protected $sort;
+    /**
+     * @var string sort order 'ascending' or 'descending'
+     */
+    protected $sortorder;
+    /**
+     * @var array
+     * @deprecated 2022-08-31 Not used/filled any more by tag plugin
+     */
+    var $topic_idx  = [];
 
     /**
      * Constructor gets default preferences and language strings
      */
-    function __construct() {
+    public function __construct() {
         global $ID;
 
         $this->namespace = $this->getConf('namespace');
@@ -35,8 +48,8 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      *
      * @return array Method description
      */
-    function getMethods() {
         $result = array();
+    public function getMethods() {
 
         $result[] = array(
             'name'   => 'overrideSortFlags',
@@ -91,7 +104,7 @@ class helper_plugin_tag extends DokuWiki_Plugin {
         return $result;
     }
 
-    function overrideSortFlags($newflags = array()) {
+    public function overrideSortFlags($newflags = []) {
         if(isset($newflags['sortkey'])) {
             $this->sort = trim($newflags['sortkey']);
         }
@@ -103,16 +116,24 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     /**
      * Returns the column header for the Pagelist Plugin
      */
-    function th() {
+    public function th() {
         return $this->getLang('tags');
     }
 
     /**
      * Returns the cell data for the Pagelist Plugin
      */
-    function td($id) {
-        $subject = $this->_getSubjectMetadata($id);
+    public function td($id) {
+        $subject = $this->getTagsFromPageMetadata($id);
         return $this->tagLinks($subject);
+    }
+
+    /**
+     *
+     * @return string|false
+     */
+    public function getNamespace() {
+        return $this->namespace;
     }
 
     /**
@@ -121,8 +142,8 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      * @param array $tags an array of tags
      * @return string HTML link tags
      */
-    function tagLinks($tags) {
         if (empty($tags) || ($tags[0] == '')) return '';
+    public function tagLinks($tags) {
 
         $links = array();
         foreach ($tags as $tag) {
@@ -139,7 +160,7 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      * @param bool   $dynamic if the link class shall be changed if no pages with the specified tag exist
      * @return string The HTML code of the link
      */
-    function tagLink($tag, $title = '', $dynamic = false) {
+    public function tagLink($tag, $title = '', $dynamic = false) {
         global $conf;
         $svtag = $tag;
         $tag_title = str_replace('_', ' ', noNS($tag));
@@ -181,27 +202,32 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      *
      * @param string $ns A namespace to which all pages need to belong, "." for only the root namespace
      * @param int    $num The maximum number of pages that shall be returned
-     * @param string $tag The tag that shall be searched
+     * @param string $tagquery The tag string that shall be searched e.g. 'tag +tag -tag'
      * @return array The list of pages
      *
      * @author  Esther Brunner <wikidesign@gmail.com>
      */
-    function getTopic($ns = '', $num = NULL, $tag = '') {
+    public function getTopic($ns = '', $num = null, $tagquery = '') {
         global $INPUT;
-        if (!$tag) $tag = $INPUT->str('tag');
-        $tag = $this->_parseTagList($tag, true);
-        $result = array();
+        if (!$tagquery) {
+            $tagquery = $INPUT->str('tag');
+        }
+        $queryTags = $this->parseTagList($tagquery, true);
+        $result = [];
 
-        // find the pages using topic.idx
-        $pages = $this->_tagIndexLookup($tag);
-        if (!count($pages)) return $result;
+        // find the pages using subject_w.idx
+        $pages = $this->getIndexedPagesMatchingTagQuery($queryTags);
+        if (!count($pages)) {
+            return $result;
+        }
 
         foreach ($pages as $page) {
             // exclude pages depending on ACL and namespace
-            if($this->_notVisible($page, $ns)) continue;
-            $tags  = $this->_getSubjectMetadata($page);
+            if($this->isNotVisible($page, $ns)) continue;
+
+            $pageTags  = $this->getTagsFromPageMetadata($page);
             // don't trust index
-            if (!$this->_checkPageTags($tags, $tag)) continue;
+            if (!$this->matchWithPageTags($pageTags, $queryTags)) continue;
 
             // get metadata
             $meta = p_get_metadata($page);
@@ -209,60 +235,66 @@ class helper_plugin_tag extends DokuWiki_Plugin {
             $perm = auth_quickaclcheck($page);
 
             // skip drafts unless for users with create privilege
-            $draft = isset($meta['type']) && $meta['type'] == 'draft';
-            if ($draft && ($perm < AUTH_CREATE)) continue;
+            $isDraft = isset($meta['type']) && $meta['type'] == 'draft';
+            if ($isDraft && $perm < AUTH_CREATE) continue;
 
             $title = $meta['title'] ?? '';
             $date  = ($this->sort == 'mdate' ? $meta['date']['modified'] : $meta['date']['created'] );
-            $taglinks = $this->tagLinks($tags);
+            $taglinks = $this->tagLinks($pageTags);
 
             // determine the sort key
             switch($this->sort) {
                 case 'id':
-                    $key = $page;
+                    $sortkey = $page;
                     break;
                 case 'ns':
                     $pos = strrpos($page, ':');
                     if ($pos === false) {
-                        $key = "\0".$page;
+                        $sortkey = "\0".$page;
                     } else {
-                        $key = substr_replace($page, "\0\0", $pos, 1);
+                        $sortkey = substr_replace($page, "\0\0", $pos, 1);
                     }
-                    $key = str_replace(':', "\0", $key);
+                    $sortkey = str_replace(':', "\0", $sortkey);
                     break;
                 case 'pagename':
-                    $key = noNS($page);
+                    $sortkey = noNS($page);
                     break;
                 case 'title':
-                    $key = utf8_strtolower($title);
-                    if (empty($key)) {
-                        $key = str_replace('_', ' ', noNS($page));
+                    $sortkey = utf8_strtolower($title);
+                    if (empty($sortkey)) {
+                        $sortkey = str_replace('_', ' ', noNS($page));
                     }
                     break;
                 default:
-                    $key = $date;
+                    $sortkey = $date;
             }
             // make sure that the key is unique
-            $key = $this->_uniqueKey($key, $result);
+            $sortkey = $this->uniqueKey($sortkey, $result);
 
-            $result[$key] = array(
+            $result[$sortkey] = [
                     'id'     => $page,
                     'title'  => $title,
                     'date'   => $date,
                     'user'   => $meta['creator'],
                     'desc'   => $meta['description']['abstract'],
-                    'cat'    => $tags[0],
+                    'cat'    => $pageTags[0],
                     'tags'   => $taglinks,
                     'perm'   => $perm,
                     'exists' => true,
-                    'draft'  => $draft, );
+                    'draft'  => $isDraft
+            ];
 
-            if ($num && count($result) >= $num) break;
+            if ($num && count($result) >= $num) {
+                break;
+            }
         }
 
         // finally sort by sort key
-        if ($this->sortorder == 'ascending') ksort($result);
-        else krsort($result);
+        if ($this->sortorder == 'ascending') {
+            ksort($result);
+        } else {
+            krsort($result);
+        }
 
         return $result;
     }
@@ -271,16 +303,21 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      * Refine found pages with tags (+tag: AND, -tag: (AND) NOT)
      *
      * @param array $pages The pages that shall be filtered, each page needs to be an array with a key "id"
-     * @param string $refine The list of tags in the form "tag +tag2 -tag3". The tags will be cleaned.
+     * @param string $tagquery The list of tags in the form "tag +tag2 -tag3". The tags will be cleaned.
      * @return array The filtered list of pages
      */
-    function tagRefine($pages, $refine) {
-        if (!is_array($pages)) return $pages; // wrong data type
-        $tags = $this->_parseTagList($refine, true);
-        $all_pages = $this->_tagIndexLookup($tags);
+    public function tagRefine($pages, $tagquery) {
+        if (!is_array($pages)) {
+            // wrong data type
+            return $pages;
+        }
+        $queryTags = $this->parseTagList($tagquery, true);
+        $allMatchedPages = $this->getIndexedPagesMatchingTagQuery($queryTags);
 
         foreach ($pages as $key => $page) {
-            if (!in_array($page['id'], $all_pages)) unset($pages[$key]);
+            if (!in_array($page['id'], $allMatchedPages)) {
+                unset($pages[$key]);
+            }
         }
 
         return $pages;
@@ -292,60 +329,65 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     * @param array $tags array of tags
     * @param array $namespaces array of namespaces where to count the tags
     * @param boolean $allTags boolean if all available tags should be counted
-    * @param boolean $recursive boolean if pages in subnamespaces are allowed
-    * @return array
+    * @param boolean $isRecursive boolean if counting of pages in subnamespaces is allowed
+    * @return array with:
+    *   $tag => int count
     */
-   function tagOccurrences($tags, $namespaces = NULL, $allTags = false, $recursive = NULL) {
+    public function tagOccurrences($tags, $namespaces = null, $allTags = false, $isRecursive = null) {
         // map with trim here in order to remove newlines from tags
         if($allTags) $tags = array_map('trim', idx_getIndex('subject', '_w'));
-        $tags = $this->_cleanTagList($tags);
-        $otags = array(); //occurrences
         if(!$namespaces || $namespaces[0] == '' || !is_array($namespaces)) $namespaces = NULL; // $namespaces not specified
+        $tags = $this->cleanTagList($tags);
+        $tagOccurrences = []; //occurrences
 
         $indexer = idx_get_indexer();
-        $indexer_pages = $indexer->lookupKey('subject', $tags, array($this, '_tagCompare'));
+        $indexedPagesWithTags = $indexer->lookupKey('subject', $tags, array($this, 'tagCompare'));
 
-        $root_allowed = ($namespaces == NULL ? false : in_array('.', $namespaces));
-        if ($recursive === NULL)
-            $recursive = $this->getConf('list_tags_of_subns');
+        $isRootAllowed = !($namespaces === null) && in_array('.', $namespaces);
+        if ($isRecursive === null)
+            $isRecursive = $this->getConf('list_tags_of_subns');
 
         foreach ($tags as $tag) {
-            if (!isset($indexer_pages[$tag])) continue;
+            if (!isset($indexedPagesWithTags[$tag])) continue;
 
             // just to be sure remove duplicate pages from the list of pages
-            $pages = array_unique($indexer_pages[$tag]);
+            $pages = array_unique($indexedPagesWithTags[$tag]);
 
             // don't count hidden pages or pages the user can't access
             // for performance reasons this doesn't take drafts into account
-            $pages = array_filter($pages, array($this, '_isVisible'));
+            $pages = array_filter($pages, [$this, 'isVisible']);
 
             if (empty($pages)) continue;
 
-            if ($namespaces == NULL || ($root_allowed && $recursive)) {
+            if ($namespaces == null || ($isRootAllowed && $isRecursive)) {
                 // count all pages
-                $otags[$tag] = count($pages);
-            } else if (!$recursive) {
+                $tagOccurrences[$tag] = count($pages);
+            } else if (!$isRecursive) {
                 // filter by exact namespace
-                $otags[$tag] = 0;
+                $tagOccurrences[$tag] = 0;
                 foreach ($pages as $page) {
                     $ns = getNS($page);
-                    if (($ns == false && $root_allowed) || in_array($ns, $namespaces)) $otags[$tag]++;
+                    if (($ns === false && $isRootAllowed) || in_array($ns, $namespaces)) {
+                        $tagOccurrences[$tag]++;
+                    }
                 }
             } else { // recursive, no root
-                $otags[$tag] = 0;
+                $tagOccurrences[$tag] = 0;
                 foreach ($pages as $page) {
                     foreach ($namespaces as $ns) {
                         if(strpos($page, $ns.':') === 0 ) {
-                            $otags[$tag]++ ;
+                            $tagOccurrences[$tag]++ ;
                             break;
                         }
                     }
                 }
             }
             // don't return tags without pages
-            if ($otags[$tag] == 0) unset($otags[$tag]);
+            if ($tagOccurrences[$tag] == 0) {
+                unset($tagOccurrences[$tag]);
+            }
         }
-        return $otags;
+        return $tagOccurrences;
     }
 
     /**
@@ -354,44 +396,49 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      * @param string $id the page id
      * @return array
      */
-    function _getSubjectMetadata($id){
+    protected function getTagsFromPageMetadata($id){
         $tags = p_get_metadata($id, 'subject');
         if (!is_array($tags)) $tags = explode(' ', $tags);
         return array_unique($tags);
     }
 
     /**
-     * Tag index lookup
+     * Returns pages from index matching the tag query
      *
-     * @param array $tags the tags to filter
+     * @param array $queryTags the tags to filter e.g. ['tag'(OR), '+tag'(AND), '-tag'(NOT)]
      * @return array the matching page ids
      */
-    function _tagIndexLookup($tags) {
-        $result = array(); // array of page ids
+    public function getIndexedPagesMatchingTagQuery($queryTags) {
+        $result = []; // array of page ids
 
-        $clean_tags = array();
-        foreach ($tags as $i => $tag) {
-            if (($tag[0] == '+') || ($tag[0] == '-'))
-                $clean_tags[$i] = substr($tag, 1);
-            else
-                $clean_tags[$i] = $tag;
+        $cleanTags = [];
+        foreach ($queryTags as $i => $tag) {
+            if ($tag[0] == '+' || $tag[0] == '-') {
+                $cleanTags[$i] = substr($tag, 1);
+            } else {
+                $cleanTags[$i] = $tag;
+            }
         }
 
         $indexer = idx_get_indexer();
-        $pages = $indexer->lookupKey('subject', $clean_tags, array($this, '_tagCompare'));
+        $pages = $indexer->lookupKey('subject', $cleanTags, [$this, 'tagCompare']);
         // use all pages as basis if the first tag isn't an "or"-tag or if there are no tags given
-        if (empty($tags) || $clean_tags[0] != $tags[0]) $result = $indexer->getPages();
+        if (empty($queryTags) || $cleanTags[0] != $queryTags[0]) {
+            $result = $indexer->getPages();
+        }
 
-        foreach ($tags as $i => $tag) {
-            $t = $clean_tags[$i];
-            if (!is_array($pages[$t])) $pages[$t] = array();
+        foreach ($queryTags as $i => $queryTag) {
+            $tag = $cleanTags[$i];
+            if (!is_array($pages[$tag])) {
+                $pages[$tag] = [];
+            }
 
-            if ($tag[0] == '+') {       // AND: add only if in both arrays
-                $result = array_intersect($result, $pages[$t]);
-            } elseif ($tag[0] == '-') { // NOT: remove array from docs
-                $result = array_diff($result, $pages[$t]);
-            } else {                   // OR: add array to docs
-                $result = array_unique(array_merge($result, $pages[$t]));
+            if ($queryTag[0] == '+') {       // AND: add only if in both arrays
+                $result = array_intersect($result, $pages[$tag]);
+            } elseif ($queryTag[0] == '-') { // NOT: remove array from docs
+                $result = array_diff($result, $pages[$tag]);
+            } else {                         // OR: add array to docs
+                $result = array_unique(array_merge($result, $pages[$tag]));
             }
         }
 
@@ -399,10 +446,15 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     }
 
 
+
     /**
      * Splits a string into an array of tags
+     *
+     * @param string $tags tag string, if containing spaces use quotes e.g. "tag with spaces", will be replaced by underscores
+     * @param bool $clean replace placeholders and clean id
+     * @return string[]
      */
-    function _parseTagList($tags, $clean = false) {
+    public function parseTagList($tags, $clean = false) {
 
         // support for "quoted phrase tags"
         if (preg_match_all('#".*?"#', $tags, $matches)) {
@@ -415,7 +467,7 @@ class helper_plugin_tag extends DokuWiki_Plugin {
         $tags = preg_split('/ /', $tags, -1, PREG_SPLIT_NO_EMPTY);
 
         if ($clean) {
-            return $this->_cleanTagList($tags);
+            return $this->cleanTagList($tags);
         } else {
             return $tags;
         }
@@ -424,16 +476,16 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     /**
      * Clean a list (array) of tags using _cleanTag
      */
-    function _cleanTagList($tags) {
-        return array_unique(array_map(array($this, '_cleanTag'), $tags));
+    public function cleanTagList($tags) {
+        return array_unique(array_map([$this, 'cleanTag'], $tags));
     }
 
     /**
      * Cleans a tag using cleanID while preserving a possible prefix of + or -
      */
-    function _cleanTag($tag) {
+    protected function cleanTag($tag) {
         $prefix = substr($tag, 0, 1);
-        $tag = $this->_applyMacro($tag);
+        $tag = $this->replacePlaceholders($tag);
         if ($prefix === '-' || $prefix === '+') {
             return $prefix.cleanID($tag);
         } else {
@@ -444,9 +496,9 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     /**
      * Makes user or date dependent topic lists possible
      */
-    function _applyMacro($id) {
         /** @var DokuWiki_Auth_Plugin $auth */
         global $INFO, $auth, $INPUT;
+    protected function replacePlaceholders($tag) {
 
         $user     = $INPUT->server->str('REMOTE_USER');
         $group    = '';
@@ -473,7 +525,7 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      * @author    Esther Brunner <wikidesign@gmail.com>
      * @author    Ilya S. Lebedev <ilya@lebedev.net>
      */
-    function _uniqueKey($key, &$result) {
+    protected function uniqueKey($key, $result) {
 
         // increase numeric keys by one
         if (is_numeric($key)) {
@@ -495,9 +547,10 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     /**
      * Opposite of _notVisible
      */
-    function _isVisible($id, $ns='') {
-        return !$this->_notVisible($id, $ns);
+    public function isVisible($id, $ns='') {
+        return !$this->isNotVisible($id, $ns);
     }
+
     /**
      * Check visibility of the page
      *
@@ -505,10 +558,11 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      * @param string $ns the namespace authorized
      * @return bool if the page is hidden
      */
-    function _notVisible($id, $ns="") {
         if (isHiddenPage($id)) return true; // discard hidden pages
+    public function isNotVisible($id, $ns="") {
         // discard if user can't read
         if (auth_quickaclcheck($id) < AUTH_READ) return true;
+
         // filter by namespace, root namespace is identified with a dot
         if($ns == '.') {
             // root namespace is specified, discard all pages who lay outside the root namespace
@@ -523,26 +577,91 @@ class helper_plugin_tag extends DokuWiki_Plugin {
     /**
      * Helper function for the indexer in order to avoid interpreting wildcards
      */
-    function _tagCompare($tag1, $tag2) {
+    public function tagCompare($tag1, $tag2) {
         return $tag1 === $tag2;
     }
 
     /**
-     * Check if the page is a real candidate for the result of the getTopic
+     * Check if the page is a real candidate for the result of the getTopic by comparing its tags with the wanted tags
      *
-     * @param array $pagetags tags on the metadata of the page
-     * @param array $tags tags we are looking
+     * @param string[] $pageTags cleaned tags from the metadata of the page
+     * @param string[] $queryTags tags we are looking ['tag', '+tag', '-tag']
      * @return bool
      */
-    function _checkPageTags($pagetags, $tags) {
+    protected function matchWithPageTags($pageTags, $queryTags) {
         $result = false;
-        foreach($tags as $tag) {
-            if ($tag[0] == "+" and !in_array(substr($tag, 1), $pagetags)) $result = false;
-            if ($tag[0] == "-" and in_array(substr($tag, 1), $pagetags)) $result = false;
-            if (in_array($tag, $pagetags)) $result = true;
+        foreach($queryTags as $tag) {
+            if ($tag[0] == "+" and !in_array(substr($tag, 1), $pageTags)) {
+                $result = false;
+            }
+            if ($tag[0] == "-" and in_array(substr($tag, 1), $pageTags)) {
+                $result = false;
+            }
+            if (in_array($tag, $pageTags)) {
+                $result = true;
+            }
         }
         return $result;
     }
 
+
+    /**
+     * @deprecated 2022-08-31 use parseTagList() instead !
+     *
+     * @param string $tags
+     * @param bool $clean
+     * @return string[]
+     */
+    public function _parseTagList($tags, $clean = false) {
+        return $this->parseTagList($tags, $clean);
+    }
+
+    /**
+     * Opposite of isNotVisible()
+     *
+     * @deprecated 2022-08-31 use isVisible() instead !
+     *
+     * @param string $id
+     * @param string $ns
+     * @return bool
+     */
+    public function _isVisible($id, $ns='') {
+        return $this->isVisible($id, $ns);
+    }
+
+    /**
+     * Clean a list (array) of tags using _cleanTag
+     *
+     * @deprecated 2022-08-31 use cleanTagList() instead !
+     *
+     * @param string[] $tags
+     * @return string[]
+     */
+    public function _cleanTagList($tags) {
+        return $this->cleanTagList($tags);
+    }
+
+    /**
+     * Returns pages from index matching the tag query
+     *
+     * @param array $queryTags the tags to filter e.g. ['tag'(OR), '+tag'(AND), '-tag'(NOT)]
+     * @return array the matching page ids
+     *
+     * @deprecated 2022-08-31 use getIndexedPagesMatchingTagQuery() instead !
+     */
+    function _tagIndexLookup($queryTags) {
+        return $this->getIndexedPagesMatchingTagQuery($queryTags);
+    }
+
+    /**
+     * Get the subject metadata cleaning the result
+     *
+     * @deprecated 2022-08-31 use getTagsFromPageMetadata() instead !
+     *
+     * @param string $id the page id
+     * @return array
+     */
+    public function _getSubjectMetadata($id){
+        return $this->getTagsFromPageMetadata($id);
+    }
 }
-// vim:ts=4:sw=4:et:

--- a/syntax/count.php
+++ b/syntax/count.php
@@ -61,7 +61,7 @@ class syntax_plugin_tag_count extends DokuWiki_Syntax_Plugin {
         /** @var helper_plugin_tag $my */
         if(!($my = $this->loadHelper('tag'))) return false;
 
-        return array($my->_parseTagList($tags), $allowedNamespaces);
+        return array($my->parseTagList($tags), $allowedNamespaces);
     }
 
     /**

--- a/syntax/count.php
+++ b/syntax/count.php
@@ -96,29 +96,28 @@ class syntax_plugin_tag_count extends DokuWiki_Syntax_Plugin {
             $class = "inline"; // valid: inline, ul, pagelist
             $col = "page";
 
-            $renderer->doc .= '<table class="'.$class.'">'.DOKU_LF;
-            $renderer->doc .= DOKU_TAB.'<tr>'.DOKU_LF.DOKU_TAB.DOKU_TAB;
+            $renderer->doc .= '<table class="'.$class.'">';
+            $renderer->doc .= '<tr>';
             $renderer->doc .= '<th class="'.$col.'">'.$this->getLang('tag').'</th>';
             $renderer->doc .= '<th class="'.$col.'">'.$this->getLang('count').'</th>';
-            $renderer->doc .= DOKU_LF.DOKU_TAB.'</tr>'.DOKU_LF;
+            $renderer->doc .= '</tr>';
 
             if(empty($occurrences)) {
                 // Skip output
-                $renderer->doc .= DOKU_TAB.'<tr>'.DOKU_LF.DOKU_TAB.DOKU_TAB;
-                $renderer->doc .= DOKU_TAB.DOKU_TAB.'<td class="'.$class.'" colspan="2">'.$this->getLang('empty_output').'</td>'.DOKU_LF;
-                $renderer->doc .= DOKU_LF.DOKU_TAB.'</tr>'.DOKU_LF;
+                $renderer->doc .= '<tr>';
+                $renderer->doc .= '<td class="'.$class.'" colspan="2">'.$this->getLang('empty_output').'</td>';
+                $renderer->doc .= '</tr>';
             } else {
                 foreach($occurrences as $tagname => $count) {
                     if($count <= 0) continue; // don't display tags with zero occurrences
-                    $renderer->doc .= DOKU_TAB.'<tr>'.DOKU_LF.DOKU_TAB.DOKU_TAB;
-                    $renderer->doc .= DOKU_TAB.DOKU_TAB.'<td class="'.$class.'">'.$my->tagLink($tagname).'</td>'.DOKU_LF;
-                    $renderer->doc .= DOKU_TAB.DOKU_TAB.'<td class="'.$class.'">'.$count.'</td>'.DOKU_LF;
-                    $renderer->doc .= DOKU_LF.DOKU_TAB.'</tr>'.DOKU_LF;
+                    $renderer->doc .= '<tr>';
+                    $renderer->doc .= '<td class="'.$class.'">'.$my->tagLink($tagname).'</td>';
+                    $renderer->doc .= '<td class="'.$class.'">'.$count.'</td>';
+                    $renderer->doc .= '</tr>';
                 }
             }
-            $renderer->doc .= '</table>'.DOKU_LF;
+            $renderer->doc .= '</table>';
         }
         return true;
     }
 }
-// vim:ts=4:sw=4:et:

--- a/syntax/searchtags.php
+++ b/syntax/searchtags.php
@@ -80,7 +80,9 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
             $configflags = explode(',', str_replace(" ", "", $this->getConf('pagelist_flags')));
             $flags = array_merge($configflags, $flags);
             foreach($flags as $key => $flag) {
-                if($flag == "")	unset($flags[$key]);
+                if($flag == "")	{
+                    unset($flags[$key]);
+                }
             }
 
             // print the search form
@@ -90,9 +92,11 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
             // get the tag input data
             $tags = $this->getTagSearchString();
 
-            if ($tags != NULL) {
-                /* @var helper_plugin_tag $my */
-                if ($my = $this->loadHelper('tag')) $pages = $my->getTopic($this->getNS(), '', $tags);
+            if ($tags != null) {
+                /* @var helper_plugin_tag $helper */
+                if ($helper = $this->loadHelper('tag')) {
+                    $pages = $helper->getTopic($this->getNS(), '', $tags);
+                }
 
                 // Display a message when no pages were found
                 if (!isset($pages) || !$pages) {
@@ -126,11 +130,11 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
 
         if (!$nonsform) {
             // Get the list of all namespaces for the dropdown
-            $namespaces = array();
-            search($namespaces,$conf['datadir'],'search_namespaces',array());
+            $namespaces = [];
+            search($namespaces,$conf['datadir'],'search_namespaces', []);
 
             // build the list in the form value => label from the namespace search result
-            $ns_select = array('' => '');
+            $ns_select = ['' => ''];
             foreach ($namespaces as $ns) {
                 // only display namespaces the user can access when sneaky index is on
                 if ($ns['perm'] > 0 || $conf['sneaky_index'] == 0) {
@@ -150,13 +154,17 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
 
         // checkbox for AND
         $attr = array();
-        if ($this->useAnd()) $attr['checked'] = 'checked';
+        if ($this->useAnd()) {
+            $attr['checked'] = 'checked';
+        }
         $form->addElement(form_makeCheckboxField('plugin__tag_search_and', 1, $this->getLang('use_and'), '', '', $attr));
         $form->addElement(form_makeCloseTag('p'));
 
         // load the tag list - only tags that actually have pages assigned that the current user can access are listed
         /* @var helper_plugin_tag $my */
-        if ($my = $this->loadHelper('tag')) $tags = $my->tagOccurrences(array(), NULL, true);
+        if ($my = $this->loadHelper('tag')) {
+            $tags = $my->tagOccurrences(array(), NULL, true);
+        }
         // sort tags by name ($tags is in the form $tag => $count)
         ksort($tags);
 
@@ -187,12 +195,16 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
                 $form->addElement(form_makeOpenTag('tr'));
                 $form->addElement(form_makeOpenTag('td'));
                 $attr = array();
-                if ($this->isSelected($tag)) $attr['checked'] = 'checked';
+                if ($this->isSelected($tag)) {
+                    $attr['checked'] = 'checked';
+                }
                 $form->addElement(form_makeCheckboxField('plugin__tag_search_tags[]', $tag, '+', '', 'plus', $attr));
                 $form->addElement(form_makeCloseTag('td'));
                 $form->addElement(form_makeOpenTag('td'));
                 $attr = array();
-                if ($this->isSelected('-'.$tag)) $attr['checked'] = 'checked';
+                if ($this->isSelected('-'.$tag)) {
+                    $attr['checked'] = 'checked';
+                }
                 $form->addElement(form_makeCheckboxField('plugin__tag_search_tags[]', '-'.$tag, '-', '', 'minus', $attr));
                 $form->addElement(form_makeCloseTag('td'));
                 $form->addElement(form_makeOpenTag('td'));
@@ -219,8 +231,9 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
      * @return string the cleaned namespace id
      */
     private function getNS() {
-        if (isset($_POST['plugin__tag_search_namespace'])) {
-            return cleanID($_POST['plugin__tag_search_namespace']);
+        global $INPUT;
+        if ($INPUT->post->has('plugin__tag_search_namespace')) {
+            return cleanID($INPUT->post->str('plugin__tag_search_namespace'));
         } else {
             return '';
         }
@@ -228,13 +241,14 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
 
     /**
      * Returns the tag search string from the selected tags
-     * @return string|NULL the tag search or NULL when no tags were selected
+     * @return string|null the tag search or null when no tags were selected
      */
     private function getTagSearchString() {
-        if (isset($_POST['plugin__tag_search_tags']) && is_array($_POST['plugin__tag_search_tags'])) {
-            $tags = $_POST['plugin__tag_search_tags'];
-            // wWhen and is set, prepend "+" to each tag
-            $plus = (isset($_POST['plugin__tag_search_and']) ? '+' : '');
+        global $INPUT;
+        if ($INPUT->post->has('plugin__tag_search_tags') && is_array($INPUT->post->param('plugin__tag_search_tags'))) {
+            $tags = $INPUT->post->arr('plugin__tag_search_tags');
+            // When 'and' is set, prepend "+" to each tag
+            $plus = $this->useAnd() ? '+' : '';
             $positive_tags = '';
             $negative_tags = '';
             foreach ($tags as $tag) {
@@ -251,7 +265,7 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
             }
             return $positive_tags.$negative_tags;
         } else {
-            return NULL; // return NULL when no tags were selected so no results will be displayed
+            return null; // return NULL when no tags were selected so no results will be displayed
         }
     }
 
@@ -262,8 +276,9 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
      * @return bool if the tag was checked
      */
     private function isSelected($tag) {
-        if (isset($_POST['plugin__tag_search_tags']) && is_array($_POST['plugin__tag_search_tags'])) {
-            return in_array($tag, $_POST['plugin__tag_search_tags'], true);
+        global $INPUT;
+        if ($INPUT->post->has('plugin__tag_search_tags')) {
+            return in_array($tag, $INPUT->post->arr('plugin__tag_search_tags'), true);
         } else {
             return false; // no tags in the post data - no tag selected
         }
@@ -275,7 +290,8 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
      * @return bool if the query should use AND
      */
     private function useAnd() {
-        return isset($_POST['plugin__tag_search_and']);
+        global $INPUT;
+        return $INPUT->post->has('plugin__tag_search_and');
     }
 }
 // vim:ts=4:sw=4:et:

--- a/syntax/searchtags.php
+++ b/syntax/searchtags.php
@@ -72,7 +72,7 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
 
             /* @var helper_plugin_pagelist $pagelist */
             // let Pagelist Plugin do the work for us
-            if ((!$pagelist = $this->loadHelper('pagelist'))) {
+            if (!$pagelist = $this->loadHelper('pagelist')) {
                 return false;
             }
 

--- a/syntax/searchtags.php
+++ b/syntax/searchtags.php
@@ -30,7 +30,7 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
      * @param string $mode Parser mode
      */
     function connectTo($mode) {
-        $this->Lexer->addSpecialPattern('\{\{searchtags\}\}',$mode,'plugin_tag_searchtags');
+        $this->Lexer->addSpecialPattern('\{\{searchtags}}', $mode,'plugin_tag_searchtags');
         // make sure that flags really start with & and media files starting with "searchtags" still work
         $this->Lexer->addSpecialPattern('\{\{searchtags&.*?\}\}',$mode,'plugin_tag_searchtags');
     }
@@ -45,7 +45,7 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
      * @return array Data for the renderer
      */
     function handle($match, $state, $pos, Doku_Handler $handler) {
-        $flags = substr($match, 10, -2); // strip {{searchtags from start and }} from end
+        $flags = substr($match, 12, -2); // strip {{searchtags from start and }} from end
         // remove empty flags by using array_filter (removes elements == false)
         $flags = array_filter(explode('&', $flags));
 

--- a/syntax/searchtags.php
+++ b/syntax/searchtags.php
@@ -47,9 +47,7 @@ class syntax_plugin_tag_searchtags extends DokuWiki_Syntax_Plugin {
     function handle($match, $state, $pos, Doku_Handler $handler) {
         $flags = substr($match, 12, -2); // strip {{searchtags from start and }} from end
         // remove empty flags by using array_filter (removes elements == false)
-        $flags = array_filter(explode('&', $flags));
-
-        return $flags;
+        return array_filter(explode('&', $flags));
     }
 
     /**

--- a/syntax/tag.php
+++ b/syntax/tag.php
@@ -57,7 +57,7 @@ class syntax_plugin_tag_tag extends DokuWiki_Syntax_Plugin {
         if (!$my = $this->loadHelper('tag')) return false;
 
         // split tags and returns for renderer
-        return $my->_parseTagList($tags);
+        return $my->parseTagList($tags);
     }
 
     /**
@@ -102,7 +102,7 @@ class syntax_plugin_tag_tag extends DokuWiki_Syntax_Plugin {
 
             // add references if tag page exists
             foreach ($data as $tag) {
-                resolve_pageid($my->namespace, $tag, $exists); // resolve shortcuts
+                resolve_pageid($my->getNamespace(), $tag, $exists); // resolve shortcuts
                 $renderer->meta['relation']['references'][$tag] = $exists;
             }
 

--- a/syntax/tag.php
+++ b/syntax/tag.php
@@ -111,4 +111,3 @@ class syntax_plugin_tag_tag extends DokuWiki_Syntax_Plugin {
         return false;
     }
 }
-// vim:ts=4:sw=4:et:

--- a/syntax/tag.php
+++ b/syntax/tag.php
@@ -112,8 +112,16 @@ class syntax_plugin_tag_tag extends DokuWiki_Syntax_Plugin {
 
             // add references if tag page exists
             foreach ($data as $tag) {
-                resolve_pageid($my->getNamespace(), $tag, $exists); // resolve shortcuts
-                $renderer->meta['relation']['references'][$tag] = $exists;
+                // resolve shortcuts
+                // Igor and later
+                if (class_exists('dokuwiki\File\PageResolver')) {
+                    $resolver = new dokuwiki\File\PageResolver($helper->getNamespace() . ':something');
+                    $tag = $resolver->resolveId($tag);
+                } else {
+                    // Compatibility with older releases
+                    resolve_pageid($helper->getNamespace(), $tag, $exists);
+                }
+                $renderer->meta['relation']['references'][$tag] = page_exists($tag);
             }
 
             return true;

--- a/syntax/tag.php
+++ b/syntax/tag.php
@@ -42,7 +42,7 @@ class syntax_plugin_tag_tag extends DokuWiki_Syntax_Plugin {
      * @param int    $state The state of the handler
      * @param int    $pos The position in the document
      * @param Doku_Handler    $handler The handler
-     * @return array Data for the renderer
+     * @return array|false Data for the renderer
      */
     function handle($match, $state, $pos, Doku_Handler $handler) {
         $tags = trim(substr($match, 6, -2));     // strip markup & whitespace
@@ -53,11 +53,13 @@ class syntax_plugin_tag_tag extends DokuWiki_Syntax_Plugin {
         if (!$tags) return false;
 
         // load the helper_plugin_tag
-        /** @var helper_plugin_tag $my */
-        if (!$my = $this->loadHelper('tag')) return false;
+        /** @var helper_plugin_tag $helper */
+        if (!$helper = $this->loadHelper('tag')) {
+            return false;
+        }
 
         // split tags and returns for renderer
-        return $my->parseTagList($tags);
+        return $helper->parseTagList($tags);
     }
 
     /**
@@ -70,18 +72,20 @@ class syntax_plugin_tag_tag extends DokuWiki_Syntax_Plugin {
      */
     function render($format, Doku_Renderer $renderer, $data) {
         if ($data === false) return false;
-        /** @var helper_plugin_tag $my */
-        if (!$my = $this->loadHelper('tag')) return false;
+        /** @var helper_plugin_tag $helper */
+        if (!$helper = $this->loadHelper('tag')) return false;
 
         // XHTML output
         if ($format == 'xhtml') {
-            $tags = $my->tagLinks($data);
+            $tags = $helper->tagLinks($data);
             if (!$tags) {
                 return true;
             }
-            $renderer->doc .= '<div class="'.$this->getConf('tags_list_css').'"><span>'.DOKU_LF.
-                DOKU_TAB.$tags.DOKU_LF.
-                '</span></div>'.DOKU_LF;
+            $renderer->doc .= '<div class="'.$this->getConf('tags_list_css').'">'
+                . '<span>'.DOKU_LF
+                . DOKU_TAB.$tags.DOKU_LF
+                . '</span>'
+                . '</div>'.DOKU_LF;
             return true;
 
         // for metadata renderer

--- a/syntax/tag.php
+++ b/syntax/tag.php
@@ -47,7 +47,7 @@ class syntax_plugin_tag_tag extends DokuWiki_Syntax_Plugin {
     function handle($match, $state, $pos, Doku_Handler $handler) {
         $tags = trim(substr($match, 6, -2));     // strip markup & whitespace
         $tags = trim($tags, "\xe2\x80\x8b"); // strip word/wordpad breaklines
-        $tags = preg_replace(array('/[[:blank:]]+/', '/\s+/'), " ", $tags);    // replace linebreaks and multiple spaces with one space character
+        $tags = preg_replace(['/[[:blank:]]+/', '/\s+/'], " ", $tags);    // replace linebreaks and multiple spaces with one space character
         $tags = preg_replace('/[\x00-\x1F\x7F]/u', '', $tags); // strip unprintable ascii code out of utf-8 coded string
 
         if (!$tags) return false;
@@ -76,7 +76,9 @@ class syntax_plugin_tag_tag extends DokuWiki_Syntax_Plugin {
         // XHTML output
         if ($format == 'xhtml') {
             $tags = $my->tagLinks($data);
-            if (!$tags) return true;
+            if (!$tags) {
+                return true;
+            }
             $renderer->doc .= '<div class="'.$this->getConf('tags_list_css').'"><span>'.DOKU_LF.
                 DOKU_TAB.$tags.DOKU_LF.
                 '</span></div>'.DOKU_LF;
@@ -88,17 +90,21 @@ class syntax_plugin_tag_tag extends DokuWiki_Syntax_Plugin {
             // erase tags on persistent metadata no more used
             if (isset($renderer->persistent['subject'])) {
                 unset($renderer->persistent['subject']);
-                $renderer->meta['subject'] = array();
+                $renderer->meta['subject'] = [];
             }
 
-            if (!isset($renderer->meta['subject'])) $renderer->meta['subject'] = array();
+            if (!isset($renderer->meta['subject'])) {
+                $renderer->meta['subject'] = [];
+            }
 
             // each registered tags in metadata and index should be valid IDs
             $data = array_map('cleanID', $data);
             // merge with previous tags and make the values unique
             $renderer->meta['subject'] = array_unique(array_merge($renderer->meta['subject'], $data));
 
-            if ($renderer->capture) $renderer->doc .= DOKU_LF.implode(' ', $data).DOKU_LF;
+            if ($renderer->capture) {
+                $renderer->doc .= DOKU_LF.implode(' ', $data).DOKU_LF;
+            }
 
             // add references if tag page exists
             foreach ($data as $tag) {

--- a/syntax/tagpage.php
+++ b/syntax/tagpage.php
@@ -87,4 +87,3 @@ class syntax_plugin_tag_tagpage extends DokuWiki_Syntax_Plugin {
         return false;
     }
 }
-// vim:ts=4:sw=4:et:

--- a/syntax/tagpage.php
+++ b/syntax/tagpage.php
@@ -49,13 +49,13 @@ class syntax_plugin_tag_tagpage extends DokuWiki_Syntax_Plugin {
      * @return array Data for the renderer
      */
     function handle($match, $state, $pos, Doku_Handler $handler) {
-        $params            = array();
-        $dump              = trim(substr($match, 10, -2)); // get given tag
-        $dump              = explode('|', $dump, 2); // split to tags, link name and options
-        $params['title']   = $dump[1];
-        $dump              = explode('&', $dump[0]);
-        $params['dynamic'] = ($dump[1] == 'dynamic');
-        $params['tag']     = trim($dump[0]);
+        $params = [];
+        $match = trim(substr($match, 10, -2)); // get given tag
+        $match = array_pad(explode('|', $match, 2), 2, ''); // split to tags, link name and options
+        $params['title'] = $match[1];
+        [$tag, $flag] = array_pad(explode('&', $match[0], 2), 2, '');
+        $params['dynamic'] = ($flag == 'dynamic');
+        $params['tag'] = trim($tag);
 
         return $params;
     }
@@ -69,7 +69,7 @@ class syntax_plugin_tag_tagpage extends DokuWiki_Syntax_Plugin {
      * @return bool If rendering was successful.
      */
     function render($format, Doku_Renderer $renderer, $data) {
-        if($data == false) return false;
+        if($data['tag'] === '') return false;
 
         if($format == "xhtml") {
             if($data['dynamic']) {
@@ -78,10 +78,12 @@ class syntax_plugin_tag_tagpage extends DokuWiki_Syntax_Plugin {
                 $renderer->nocache();
             }
 
-            /** @var helper_plugin_tag $my */
-            if(!($my = $this->loadHelper('tag'))) return false;
+            /** @var helper_plugin_tag $helper */
+            if(!$helper = $this->loadHelper('tag')) {
+                return false;
+            }
 
-            $renderer->doc .= $my->tagLink($data['tag'], $data['title'], $data['dynamic']);
+            $renderer->doc .= $helper->tagLink($data['tag'], $data['title'], $data['dynamic']);
             return true;
         }
         return false;

--- a/syntax/topic.php
+++ b/syntax/topic.php
@@ -30,6 +30,8 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
      * @param string $mode Parser mode
      */
     function connectTo($mode) {
+        //syntax without options catches wrong used syntax too
+        $this->Lexer->addSpecialPattern('\{\{topic>}\}',$mode,'plugin_tag_topic');
         $this->Lexer->addSpecialPattern('\{\{topic>.+?\}\}',$mode,'plugin_tag_topic');
     }
 
@@ -139,4 +141,3 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
         return false;
     }
 }
-// vim:ts=4:sw=4:et:

--- a/syntax/topic.php
+++ b/syntax/topic.php
@@ -46,7 +46,6 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
      */
     function handle($match, $state, $pos, Doku_Handler $handler) {
         global $ID;
-
         $match = substr($match, 8, -2); // strip {{topic> from start and }} from end
         list($match, $flags) = array_pad(explode('&', $match, 2), 2, '');
         $flags = explode('&', $flags);
@@ -57,11 +56,15 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
             $ns   = '';
         }
 
-        if (($ns == '*') || ($ns == ':')) $ns = '';
-        elseif ($ns == '.') $ns = getNS($ID);
-        else $ns = cleanID($ns);
+        if ($ns == '*' || $ns == ':') {
+            $ns = '';
+        } elseif ($ns == '.') {
+            $ns = getNS($ID);
+        } else {
+            $ns = cleanID($ns);
+        }
 
-        return array($ns, trim($tag), $flags);
+        return [$ns, trim($tag), $flags];
     }
 
     /**
@@ -76,7 +79,7 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
         list($ns, $tag, $flags) = $data;
 
         /* extract sort flags into array */
-        $sortflags = array();
+        $sortflags = [];
         foreach($flags as $flag) {
             $separator_pos = strpos($flag, '=');
             if ($separator_pos === false) {
@@ -86,15 +89,15 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
             $conf_name = trim(strtolower(substr($flag, 0 , $separator_pos)));
             $conf_val = trim(strtolower(substr($flag, $separator_pos+1)));
 
-            if(in_array($conf_name, array('sortkey', 'sortorder'))) {
+            if(in_array($conf_name, ['sortkey', 'sortorder'])) {
                 $sortflags[$conf_name] = $conf_val;
             }
         }
 
-        /* @var helper_plugin_tag $my */
-        if ($my = $this->loadHelper('tag')) {
-            $my->overrideSortFlags($sortflags);
-            $pages = $my->getTopic($ns, '', $tag);
+        /* @var helper_plugin_tag $helper */
+        if ($helper = $this->loadHelper('tag')) {
+            $helper->overrideSortFlags($sortflags);
+            $pages = $helper->getTopic($ns, '', $tag);
         }
 
         if (!isset($pages) || !$pages) return true; // nothing to display
@@ -107,7 +110,7 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
 
             /* @var helper_plugin_pagelist $pagelist */
             // let Pagelist Plugin do the work for us
-            if ((!$pagelist = $this->loadHelper('pagelist'))) {
+            if (!$pagelist = $this->loadHelper('pagelist')) {
                 return false;
             }
             $pagelist->sort = false;
@@ -116,7 +119,9 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
             $configflags = explode(',', str_replace(" ", "", $this->getConf('pagelist_flags')));
            	$flags = array_merge($configflags, $flags);
            	foreach($flags as $key => $flag) {
-           		if($flag == "")	unset($flags[$key]);
+           		if($flag == "") {
+                    unset($flags[$key]);
+                }
            	}
 
             $pagelist->setFlags($flags);
@@ -129,7 +134,9 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
                 };
             	usort($pages, $fnc);
             	// rsort is true - revserse sort the pages
-            	if($pagelist->rsort) krsort($pages);
+            	if($pagelist->rsort) {
+                    krsort($pages);
+                }
             }
 
             foreach ($pages as $page) {

--- a/syntax/topic.php
+++ b/syntax/topic.php
@@ -48,9 +48,9 @@ class syntax_plugin_tag_topic extends DokuWiki_Syntax_Plugin {
         global $ID;
 
         $match = substr($match, 8, -2); // strip {{topic> from start and }} from end
-        list($match, $flags) = explode('&', $match, 2);
+        list($match, $flags) = array_pad(explode('&', $match, 2), 2, '');
         $flags = explode('&', $flags);
-        list($ns, $tag) = explode('?', $match);
+        list($ns, $tag) = array_pad(explode('?', $match), 2, '');
 
         if (!$tag) {
             $tag = $ns;


### PR DESCRIPTION
Some fixing of PHP 8 notices


explode() of a string which does not contain the $separator, will throw:
`PHP Notice:  Undefined offset: 1 in /.../dokuwiki/lib/plugins/tag/syntax/topic.php on line 51`.
This is an internal process, so can not be fixed by us? so why a notice? solution/workaround is trailing all strings already by the separator..