### PR TITLE
Use $USERINFO instead of $INFO['userinfo']

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -547,21 +547,24 @@ class helper_plugin_tag extends DokuWiki_Plugin {
      * @return string
      */
     protected function replacePlaceholders($tag) {
-        global $INFO, $INPUT;
+        global $USERINFO, $INPUT;
 
         $user = $INPUT->server->str('REMOTE_USER');
 
         //only available for logged-in users
-        if(isset($INFO['userinfo']['grps'])) {
-            $group = $INFO['userinfo']['grps'][0];
-        }   else {
+        if($USERINFO) {
+            $name  = cleanID($USERINFO['name']);
+            // FIXME or delete, is unreliable because just first entry of group array is used, regardless the order of groups..
+            $group = cleanID($USERINFO['grps'][0]);
+        } else {
+            $name  = '';
             $group = '';
         }
 
         $replace = [
                 '@USER@'  => cleanID($user),
-                '@NAME@'  => cleanID($INFO['userinfo']['name'] ?? ''),
-                '@GROUP@' => cleanID($group), //FIXME or delete, is unreliable because just first entry of group array is used, regardless the order of groups..
+                '@NAME@'  => $name,
+                '@GROUP@' => $group,
                 '@YEAR@'  => date('Y'),
                 '@MONTH@' => date('m'),
                 '@DAY@'   => date('d'),


### PR DESCRIPTION
Tying up loose ends following closure of #238, as mentioned in https://github.com/dokufreaks/plugin-tag/pull/238#issuecomment-1292660832

Feel free to close without merging if you think this change is not appropriate.